### PR TITLE
python: Expose derivedFrom on the peripheral model

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -126,7 +126,7 @@ class SVDInterrupt(SVDElement):
 
 class SVDPeripheral(SVDElement):
 
-    def __init__(self, name, description, prepend_to_name, base_address, address_block, interrupts, registers):
+    def __init__(self, name, description, prepend_to_name, base_address, address_block, interrupts, registers, derived_from):
         SVDElement.__init__(self)
         self.name = name
         self.description = description
@@ -135,8 +135,9 @@ class SVDPeripheral(SVDElement):
         self.address_block = address_block
         self.interrupts = interrupts
         self.registers = registers
-        
-   
+        self.derived_from = derived_from
+
+
 class SVDCpu(SVDElement):
 
     def __init__(self, name, revision, endian, mpu_present, fpu_present, vtor_present, nvic_prio_bits, vendor_systick_config):

--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -196,6 +196,7 @@ class SVDParser(object):
             address_block=address_block,
             interrupts=interrupts,
             registers=registers,
+            derived_from=peripheral_node.get('derivedFrom'),
         )
 
     def _parse_device(self, device_node):

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -79,6 +79,7 @@ class TestParserFreescale(unittest.TestCase):
         self.assertEqual(uart0.description, "Universal Asynchronous Receiver/Transmitter")
         self.assertEqual(uart0.prepend_to_name, "UART0_")
         self.assertEqual(uart0.base_address, 0x4006A000)
+        self.assertEqual(uart0.derived_from, None)
 
         # address block verification
         block = uart0.address_block


### PR DESCRIPTION
This attribute is important when a peripheral is derived from another,
in which case some data (e.g. registers) need to be retrieved from the
peripheral identified by this attribute.

For an example, see RTC1 on Nordic/nrf51.svd, which is derived from
RTC0.