### PR TITLE
setup: do not depend on setuptools-markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - "3.5"
   - "pypy"
   - "pypy3"
+addons:
+  apt:
+    packages:
+      - pandoc
 before_install:
   - cd python
 install: "pip install -r dev-requirements.txt"

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,12 +28,20 @@ def read_version(filename):
             f.read().decode('utf-8')).group(1)))
 
 
+def get_long_description():
+    try:
+        import pypandoc
+        long_description = pypandoc.convert('README.md', 'rst')
+    except ImportError:
+        long_description = open('README.md').read()
+
+
 setup(
     name="cmsis-svd",
     version=read_version(os.path.join('cmsis_svd/__init__.py')),
     url="https://github.com/posborne/cmsis-svd",
     description="CMSIS SVD data files and parser",
-    long_description_markdown_filename="README.md",
+    long_description=get_long_description(),
     author="Paul Osborne",
     author_email="osbpau@gmail.com",
     license="Apache 2.0",
@@ -52,9 +60,6 @@ setup(
     ],
     install_requires=[
         'six>=1.10',
-    ],
-    setup_requires=[
-        'setuptools-markdown>=0.1',
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Despite the convenience of setuptools-markdown, it (or pypandoc)
appears to be causing issues for some poeple.  Instead, we just
fall back on reading the README directly for long_description
(which mostly matters for displaying on pypi).

This should address #34

CC @flit @c1728p9