### PR TITLE
Simplify logic and make objects more pythonic

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -14,391 +14,145 @@
 # limitations under the License.
 #
 import json
-import six
+from itertools import count
 
-# Sentinel value for lookup where None might be a valid value
-NOT_PRESENT = object()
-TO_DICT_SKIP_KEYS = {"_register_arrays", "parent"}
 REGISTER_PROPERTY_KEYS = {"size", "access", "protection", "reset_value", "reset_mask"}
 LIST_TYPE_KEYS = {"register_arrays", "registers", "fields", "peripherals", "interrupts"}
 
-
-def _check_type(value, expected_type):
-    """Perform type checking on the provided value
-
-    This is a helper that will raise ``TypeError`` if the provided value is
-    not an instance of the provided type.  This method should be used sparingly
-    but can be good for preventing problems earlier when you want to restrict
-    duck typing to make the types of fields more obvious.
-
-    If the value passed the type check it will be returned from the call.
-    """
-    if not isinstance(value, expected_type):
-        raise TypeError("Value {value!r} has unexpected type {actual_type!r}, expected {expected_type!r}".format(
-            value=value,
-            expected_type=expected_type,
-            actual_type=type(value),
-        ))
-    return value
-
-
-def _none_as_empty(v):
-    if v is not None:
-        for e in v:
-            yield e
-
-
-class SVDJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, SVDElement):
-            eldict = {}
-            for k, v in six.iteritems(obj.__dict__):
-                if k in TO_DICT_SKIP_KEYS:
-                    continue
-                if k.startswith("_"):
-                    pubkey = k[1:]
-                    eldict[pubkey] = getattr(obj, pubkey)
-                else:
-                    eldict[k] = v
-            return eldict
-        else:
-            return json.JSONEncoder.default(self, obj)
-
-
-class SVDElement(object):
+class Element(object):
     """Base class for all SVD Elements"""
 
-    def __init__(self):
-        self.parent = None
+    def __init__(self, node, parent, name, elements=None, **kwargs):
+        self.node = node
+        self.name = name
+        self.parent = parent
 
-    def _lookup_possibly_derived_attribute(self, attr):
-        derived_from = self.get_derived_from()
+        self.__dict__.update(kwargs)
+        self._xml_fields = ['name', *kwargs.keys()]
 
-        # see if there is an attribute with the same name and leading underscore
-        try:
-            value_self = object.__getattribute__(self, "_{}".format(attr))
-        except AttributeError:
-            value_self = NOT_PRESENT
+        self._elements = {}
+        if parent is not None:
+            parent._register_element(self)
 
-        # if not, then this is an attribute error
-        if value_self is NOT_PRESENT:
-            raise AttributeError("Requested missing key")
+        if elements is not None:
+            setattr(self, elements, self._elements)
 
-        # if there is a non-None value, that is what we want to use
-        elif value_self is not None:
-            return value_self  # if there is a non-None value, use it
+    def _register_element(self, elem):
+        self._elements[elem.name] = elem
 
-        # if there is a derivedFrom, check there first
-        elif derived_from is not None:
-            derived_value = getattr(derived_from, attr, NOT_PRESENT)
-            if derived_value is not NOT_PRESENT:
-                return derived_value
+    def __getitem__(self, name):
+        return self._elements[name]
 
+    def __iter__(self):
+        return iter(self._elements.values())
+
+        # FIXME
         # for some attributes, try to grab from parent
         if attr in REGISTER_PROPERTY_KEYS:
             value = getattr(self.parent, attr, value_self)
-        else:
-            value = value_self
-
         # if value is None and this is a list type, transform to empty list
         if value is None and attr in LIST_TYPE_KEYS:
             value = []
 
-        return value
-
-    def get_derived_from(self):
-        pass  # override in children
-
     def to_dict(self):
-        # This is a little convoluted but it works and ensures a
-        # json-compatible dictionary representation (at the cost of
-        # some computational overhead)
-        encoder = SVDJSONEncoder()
-        return json.loads(encoder.encode(self))
+        def dictify(v):
+            if isinstance(v, Element):
+                return v.to_dict()
+            elif isinstance(v, list):
+                return [ dictify(e) for e in v ]
+            elif isinstance(v, dict):
+                return { k: dictivy(e) for k, e in v.items() }
+            else:
+                return v
+        return { k: dictify(getattr(self, v)) for k in self._xml_fields }
 
+class EnumeratedValue(Element):
+    pass
 
-class SVDEnumeratedValue(SVDElement):
-    def __init__(self, name, description, value, is_default):
-        SVDElement.__init__(self)
-        self.name = name
-        self.description = description
-        self.value = value
-        self.is_default = is_default
-
-
-class SVDField(SVDElement):
-    def __init__(self, name, derived_from, description, bit_offset, bit_width, access, enumerated_values, modified_write_values, read_action):
-        SVDElement.__init__(self)
-        self.name = name
-        self.derived_from = derived_from
-        self.description = description
-        self.bit_offset = bit_offset
-        self.bit_width = bit_width
-        self.access = access
-        self.enumerated_values = enumerated_values
-        self.modified_write_values = modified_write_values
-        self.read_action = read_action
-
-    def __getattr__(self, attr):
-        return self._lookup_possibly_derived_attribute(attr)
-
-    def get_derived_from(self):
-        # TODO: add support for dot notation derivedFrom
-        if self.derived_from is None:
-            return None
-
-        for field in self.parent.fields:
-            if field.name == self.derived_from:
-                return field
-
-        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+class Field(Element):
+    def __init__(self, **kwargs):
+        super().__init__(elements='enumerated_values', **kwargs)
 
     @property
     def is_enumerated_type(self):
         """Return True if the field is an enumerated type"""
-        return self.enumerated_values is not None
+        return bool(self.enumerated_values)
 
     @property
     def is_reserved(self):
-        return self.name.lower() == "reserved"
+        return 'reserved' in self.name.lower()
 
+    def __repr__(self):
+        return '<Field {self.name} ({self.description}) {self.bit_width}bit@0x{addr:0{width}x}+{self.bit_offset}>'.format(
+                self=self,
+                addr=self.parent.address_offset,
+                width=self.parent.size//4)
 
-class SVDRegisterArray(SVDElement):
+class Register(Element):
+    def __init__(self, is_array=False, **kwargs):
+        # When deriving a register, it is mandatory to specify at least the name, the description, and the addressOffset
+        super().__init__(elements='fields', is_array=is_array, **kwargs)
+
+    @property
+    def is_reserved(self):
+        return 'reserved' in self.name.lower()
+
+    def __repr__(self):
+        access = self.access.replace('read', 'R').replace('write', 'W').replace('-', '') if self.access else ''
+        fields = '[{}]'.format(', '.join('{}:{}'.format(field.name, field.bit_width) for field in self)) if self.fields else ''
+        return '<Reg {self.name} ({self.description}) @0x{self.address_offset:0{width}x} {access} {fields}>'.format(
+                self=self,
+                width=self.size//4,
+                access=access,
+                fields=fields)
+
+class RegisterArray(Register):
     """Represent a register array in the tree"""
 
-    def __init__(self, name, derived_from, description, address_offset, size,
-                 access, protection, reset_value, reset_mask, fields,
-                 display_name, alternate_group, modified_write_values,
-                 read_action, dim, dim_indices, dim_increment):
-        SVDElement.__init__(self)
+    def __init__(self, name, dim_indices, **kwargs):
+        super().__init__(name=name.replace('%s', ''), **kwargs)
 
-        # When deriving a register, it is mandatory to specify at least the name, the description,
-        # and the addressOffset
-        self.derived_from = derived_from
-        self.name = name
-        self.description = description
-        self.address_offset = address_offset
-        self.dim = dim
-        self.dim_indices = dim_indices
-        self.dim_increment = dim_increment
+        self.registers = {}
+        for idx, offx in zip(dim_indices, count(self.address_offset, self.dim_increment)):
+            reg = Register(name=name.replace('%s', str(idx)), is_array=True, parent=self, address_offset=offx, **kwargs)
+            reg._xml_fields = ['name', 'address_offset']
+            self.registers[idx] = reg
 
-        self._read_action = read_action
-        self._modified_write_values = modified_write_values
-        self._display_name = display_name
-        self._alternate_group = alternate_group
-        self._size = size
-        self._access = access
-        self._protection = protection
-        self._reset_value = reset_value
-        self._reset_mask = reset_mask
-        self._fields = fields
+class AddressBlock(Element):
+    def __repr__(self):
+        return '<Address block: {self.size} bytes @{self.offset:0{width}x}>'.format(self=self, width=self.parent.size//4)
 
-        # make parent association
-        for field in self._fields:
-            field.parent = self
+class Interrupt(Element):
+    def __repr__(self):
+        return '<Interrupt {self.name} (IRQn {self.value})>'.format(self=self)
 
-    def __getattr__(self, attr):
-        return self._lookup_possibly_derived_attribute(attr)
+class Peripheral(Element):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.interrupts = {}
+        self.address_blocks = {}
+        self.registers = {}
 
-    @property
-    def registers(self):
-        for i in six.moves.range(self.dim):
-            reg = SVDRegister(
-                name=self.name % self.dim_indices[i],
-                fields=self._fields,
-                derived_from=self.derived_from,
-                description=self.description,
-                address_offset=self.address_offset + self.dim_increment * i,
-                size=self._size,
-                access=self._access,
-                protection=self._protection,
-                reset_value=self._reset_value,
-                reset_mask=self._reset_mask,
-                display_name=self._display_name,
-                alternate_group=self._alternate_group,
-                modified_write_values=self._modified_write_values,
-                read_action=self._read_action,
-            )
-            reg.parent = self.parent
-            yield reg
+    def _register_element(self, elem):
+        super()._register_element(elem)
+        {Interrupt:     self.interrupts,
+         Register:      self.registers,
+         AddressBlock:  self.address_blocks}[type(elem)][elem.name] = elem
 
-    def get_derived_from(self):
-        # TODO: add support for dot notation derivedFrom
-        if self.derived_from is None:
-            return None
+    def __iter__(self):
+        return iter(self.registers.values())
 
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
+    def __repr__(self):
+        return '<{name} peripheral @0x{addr:0{width}x}>'.format(name=self.name, addr=self.base_address, width=self.size//4)
 
-        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+class Cpu(Element):
+    pass
 
-    def is_reserved(self):
-        return 'reserved' in self.name.lower()
+class Device(Element):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.peripherals = self._elements
 
+    def __repr__(self):
+        return '<Device: {} ({}-bit), {} peripherals>'.format(self.name, self.size, len(self.peripherals))
 
-class SVDRegister(SVDElement):
-    def __init__(self, name, derived_from, description, address_offset, size, access, protection, reset_value, reset_mask,
-                 fields, display_name, alternate_group, modified_write_values, read_action):
-        SVDElement.__init__(self)
-
-        # When deriving a register, it is mandatory to specify at least the name, the description,
-        # and the addressOffset
-        self.derived_from = derived_from
-        self.name = name
-        self.description = description
-        self.address_offset = address_offset
-
-        self._read_action = read_action
-        self._modified_write_values = modified_write_values
-        self._display_name = display_name
-        self._alternate_group = alternate_group
-        self._size = size
-        self._access = access
-        self._protection = protection
-        self._reset_value = reset_value
-        self._reset_mask = reset_mask
-        self._fields = fields
-
-        # make parent association
-        for field in self._fields:
-            field.parent = self
-
-    def __getattr__(self, attr):
-        return self._lookup_possibly_derived_attribute(attr)
-
-    def get_derived_from(self):
-        # TODO: add support for dot notation derivedFrom
-        if self.derived_from is None:
-            return None
-
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
-
-        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
-
-    def is_reserved(self):
-        return 'reserved' in self.name.lower()
-
-
-class SVDAddressBlock(SVDElement):
-    def __init__(self, offset, size, usage):
-        SVDElement.__init__(self)
-        self.offset = offset
-        self.size = size
-        self.usage = usage
-
-
-class SVDInterrupt(SVDElement):
-    def __init__(self, name, value):
-        SVDElement.__init__(self)
-        self.name = name
-        self.value = _check_type(value, six.integer_types)
-
-
-class SVDPeripheral(SVDElement):
-    def __init__(self, name, version, derived_from, description, prepend_to_name, base_address, address_block,
-                 interrupts, registers, register_arrays, size, access, protection, reset_value, reset_mask,
-                 group_name, append_to_name, disable_condition):
-        SVDElement.__init__(self)
-
-        # items with underscore are potentially derived
-        self.name = name
-        self._version = version
-        self._derived_from = derived_from
-        self._description = description
-        self._prepend_to_name = prepend_to_name
-        self._base_address = base_address
-        self._address_block = address_block
-        self._interrupts = interrupts
-        self._registers = registers
-        self._register_arrays = register_arrays
-        self._size = size  # Defines the default bit-width of any register contained in the device (implicit inheritance).
-        self._access = access  # Defines the default access rights for all registers.
-        self._protection = protection  # Defines extended access protection for all registers.
-        self._reset_value = reset_value  # Defines the default value for all registers at RESET.
-        self._reset_mask = reset_mask  # Identifies which register bits have a defined reset value.
-        self._group_name = group_name
-        self._append_to_name = append_to_name
-        self._disable_condition = disable_condition
-
-        # make parent association for complex node types
-        for i in _none_as_empty(self._interrupts):
-            i.parent = self
-        for r in _none_as_empty(self._registers):
-            r.parent = self
-
-    def __getattr__(self, attr):
-        return self._lookup_possibly_derived_attribute(attr)
-
-    @property
-    def registers(self):
-        regs = []
-        for reg in self._lookup_possibly_derived_attribute('registers'):
-            regs.append(reg)
-        for arr in self._lookup_possibly_derived_attribute('register_arrays'):
-            regs.extend(arr.registers)
-        return regs
-
-    def get_derived_from(self):
-        if self._derived_from is None:
-            return None
-
-        # find the peripheral with this name in the tree
-        try:
-            return [p for p in self.parent.peripherals if p.name == self._derived_from][0]
-        except IndexError:
-            return None
-
-
-class SVDCpu(SVDElement):
-    def __init__(self, name, revision, endian, mpu_present, fpu_present, fpu_dp, icache_present,
-                 dcache_present, itcm_present, dtcm_present, vtor_present, nvic_prio_bits,
-                 vendor_systick_config, device_num_interrupts, sau_num_regions, sau_regions_config):
-        SVDElement.__init__(self)
-
-        self.name = name
-        self.revision = revision
-        self.endian = endian
-        self.mpu_present = mpu_present
-        self.fpu_present = fpu_present
-        self.fpu_dp = fpu_dp
-        self.icache_present = icache_present,
-        self.dcache_present = dcache_present,
-        self.itcm_present = itcm_present,
-        self.dtcm_present = dtcm_present,
-        self.vtor_present = vtor_present
-        self.nvic_prio_bits = nvic_prio_bits
-        self.vendor_systick_config = vendor_systick_config
-        self.device_num_interrupts = device_num_interrupts
-        self.sau_num_regions = sau_num_regions
-        self.sau_regions_config = sau_regions_config
-
-
-class SVDDevice(SVDElement):
-    def __init__(self, vendor, vendor_id, name, version, description, cpu, address_unit_bits, width,
-                 peripherals, size, access, protection, reset_value, reset_mask):
-        SVDElement.__init__(self)
-
-        self.vendor = vendor
-        self.vendor_id = vendor_id
-        self.name = name
-        self.version = version
-        self.description = description
-        self.cpu = cpu
-        self.address_unit_bits = _check_type(address_unit_bits, six.integer_types)
-        self.width = _check_type(width, six.integer_types)
-        self.peripherals = peripherals
-        self.size = size  # Defines the default bit-width of any register contained in the device (implicit inheritance).
-        self.access = access  # Defines the default access rights for all registers.
-        self.protection = protection  # Defines extended access protection for all registers.
-        self.reset_value = reset_value  # Defines the default value for all registers at RESET.
-        self.reset_mask = reset_mask  # Identifies which register bits have a defined reset value.
-
-        # set up parent relationship
-        if self.cpu:
-            self.cpu.parent = self
-
-        for p in _none_as_empty(self.peripherals):
-            p.parent = self


### PR DESCRIPTION
First off, awesome project. Thank you for this!

I just tired it out and I found two things sort of lacking. One, I was craving for more useful reprs, so I made this:
```python
>>> device
<Device: STM32F030 (32-bit), 31 peripherals>
>>> usart1
<USART1 peripheral @0x40013800>
>>> usart1_cr1
<Reg CR1 (Control register 1) @0x00000000 RW [EOBIE:1, DEDT:5, OVER8:1, WAKE:1, TCIE:1, M:1, TE:1, RTOIE:1, IDLEIE:1, MME:1, RXNEIE:1, M1:1, PEIE:1, RE:1, DEAT:5, PS:1, UESM:1, PCE:1, UE:1, CMIE:1, TXEIE:1]>
```

Then I found that navigating the object tree is quite cumbersome as-is, so I did some refactoring to understand the code and added dict-like accessors for everyting:
```python
In [8]: dev['DMA1'].interrupts
Out[8]: 
{'DMA1_CH1': <Interrupt DMA1_CH1 (IRQn 9)>,
 'DMA1_CH2_3': <Interrupt DMA1_CH2_3 (IRQn 10)>,
 'DMA1_CH4_5': <Interrupt DMA1_CH4_5 (IRQn 11)>}

In [9]: dev['USART1'].registers['CR1'].fields
Out[9]: 
{'CMIE': <Field CMIE (Character match interrupt enable) 1bit@0x00000000+14>,
 'DEAT': <Field DEAT (Driver Enable assertion time) 5bit@0x00000000+21>,
 'DEDT': <Field DEDT (Driver Enable deassertion time) 5bit@0x00000000+16>,
 'EOBIE': <Field EOBIE (End of Block interrupt enable) 1bit@0x00000000+27>,
 'IDLEIE': <Field IDLEIE (IDLE interrupt enable) 1bit@0x00000000+4>,
 'M': <Field M (Word length) 1bit@0x00000000+12>,
 'M1': <Field M1 (Word length) 1bit@0x00000000+28>,
 'MME': <Field MME (Mute mode enable) 1bit@0x00000000+13>,
 'OVER8': <Field OVER8 (Oversampling mode) 1bit@0x00000000+15>,
 'PCE': <Field PCE (Parity control enable) 1bit@0x00000000+10>,
 'PEIE': <Field PEIE (PE interrupt enable) 1bit@0x00000000+8>,
 'PS': <Field PS (Parity selection) 1bit@0x00000000+9>,
 'RE': <Field RE (Receiver enable) 1bit@0x00000000+2>,
 'RTOIE': <Field RTOIE (Receiver timeout interrupt enable) 1bit@0x00000000+26>,
 'RXNEIE': <Field RXNEIE (RXNE interrupt enable) 1bit@0x00000000+5>,
 'TCIE': <Field TCIE (Transmission complete interrupt enable) 1bit@0x00000000+6>,
 'TE': <Field TE (Transmitter enable) 1bit@0x00000000+3>,
 'TXEIE': <Field TXEIE (interrupt enable) 1bit@0x00000000+7>,
 'UE': <Field UE (USART enable) 1bit@0x00000000+0>,
 'UESM': <Field UESM (USART enable in Stop mode) 1bit@0x00000000+1>,
 'WAKE': <Field WAKE (Receiver wakeup method) 1bit@0x00000000+11>}
```

I certainly broke lots of stuff and I did not test this thing properly, but it seems to work for me and I thought I'd show it to you even just for inspiration.

Have a nice day,
jaseg