### PR TITLE
model: when grabbing derived_from attributes use raw from derived

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -90,7 +90,7 @@ class SVDElement(object):
 
         # if there is a derivedFrom, check there first
         elif derived_from is not None:
-            derived_value = getattr(derived_from, attr, NOT_PRESENT)
+            derived_value = getattr(derived_from, "_{}".format(attr), NOT_PRESENT)
             if derived_value is not NOT_PRESENT:
                 return derived_value
 

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -283,6 +283,14 @@ class TestParserNordic(unittest.TestCase):
         self.assertEqual(reg.address_offset, 0x58C)
 
 
+class TestParserExample(unittest.TestCase):
+    def test_derived_from_registers(self):
+        parser = SVDParser.for_packaged_svd('ARM_SAMPLE', 'ARM_Sample.svd')
+        regs = {p.name: p.registers for p in parser.get_device().peripherals}
+        self.assertEqual(len(regs["TIMER0"]), len(regs["TIMER1"]))
+        self.assertEqual(len(regs["TIMER0"]), len(regs["TIMER2"]))
+        self.assertEqual(len(regs["TIMER1"]), len(regs["TIMER2"]))
+
 class TestParserPackagedData(unittest.TestCase):
     def test_packaged_xml(self):
         parser = SVDParser.for_packaged_svd('Freescale', 'MK20D7.svd')


### PR DESCRIPTION
For cases like getting the registers on a peripheral where we have
somewhat complex logic (registers is computed as the combination of
direct registers and arrays) we get into trouble get doing getattr
on the base name rather than the underscore version.

Fixes #59