### PR TITLE
fix deviceNumInterrupts and sauNumRegions

### DIFF
--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -514,8 +514,8 @@ class SVDParser(object):
             vtor_present=_get_int(cpu_node, 'vtorPresent'),
             nvic_prio_bits=_get_int(cpu_node, 'nvicPrioBits'),
             vendor_systick_config=_get_int(cpu_node, 'vendorSystickConfig'),
-            device_num_interrupts=_get_int(cpu_node, 'vendorSystickConfig'),
-            sau_num_regions=_get_int(cpu_node, 'vendorSystickConfig'),
+            device_num_interrupts=_get_int(cpu_node, 'deviceNumInterrupts'),
+            sau_num_regions=_get_int(cpu_node, 'sauNumRegions'),
             sau_regions_config=_get_text(cpu_node, 'sauRegionsConfig')
         )
 


### PR DESCRIPTION
parser was creating SVDCpu fields from the wrong source in SVD file.
Fixed two errors, so now the number of interrupt vectors is properly populated in the CPU object.