### PR TITLE
e310x: fix PWM counter offset

### DIFF
--- a/data/SiFive-Community/e310x.svd
+++ b/data/SiFive-Community/e310x.svd
@@ -2070,7 +2070,7 @@
         <register>
           <name>count</name>
           <description>Counter Register</description>
-          <addressOffset>0x04</addressOffset>
+          <addressOffset>0x08</addressOffset>
         </register>
 
         <register>


### PR DESCRIPTION
This fix (https://github.com/riscv-rust/e310x/pull/17) comes from the original repository where the SVD file has been copied.