### PR TITLE
fix: register name in k210 definition

### DIFF
--- a/data/Kendryte-Community/k210.svd
+++ b/data/Kendryte-Community/k210.svd
@@ -964,8 +964,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>interrupt mask</name>
-                    <description>intr_mask</description>
+                    <name>intr_mask</name>
+                    <description>interrupt mask</description>
                     <addressOffset>0x18</addressOffset>
                     <size>64</size>
                     <fields>


### PR DESCRIPTION
This fixes a small error where the register name and description are inversed.

The fix has also been proposed in the upstream file https://github.com/riscv-rust/k210-pac/pull/34.