### PR TITLE
Add SVD for the ESP8266

### DIFF
--- a/data/Espressif-Community/README.md
+++ b/data/Espressif-Community/README.md
@@ -7,3 +7,5 @@ could not be extracted automatically.
 
   * esp32.svd: copied from the file at
     https://github.com/esp-rs/esp32/blob/master/svd/esp32.svd
+  * esp8266.svd: generated using `make` from the repo:
+    https://github.com/esp-rs/esp8266

--- a/data/Espressif-Community/esp8266.svd
+++ b/data/Espressif-Community/esp8266.svd
@@ -1,0 +1,6953 @@
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xsi:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1.0.xsd">
+    <name>esp8266</name>
+    <version>1.0</version>
+    <width>32</width>
+    <cpu>
+        <name>Xtensa LX106</name>
+        <revision>1</revision>
+        <endian>little</endian>
+        <mpuPresent>false</mpuPresent>
+        <fpuPresent>true</fpuPresent>
+        <nvicPrioBits>3</nvicPrioBits>
+        <vendorSystickConfig>false</vendorSystickConfig>
+    </cpu>
+    <peripherals>
+        <peripheral>
+            <name>DPORT</name>
+            <baseAddress>0x3ff00000</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000040</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>EDGE_INT_ENABLE</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>EDGE_INT_ENABLE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>wdt_edge_int_enable</name><description>Enable the watchdog timer edge interrupt</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>timer1_edge_int_enable</name><description>Enable the timer1 edge interrupt</description><bitOffset>1</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>DPORT_CTL</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>DPORT_CTL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>DPORT_CTL_DOUBLE_CLK</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>EFUSE</name>
+            <baseAddress>0x3ff00050</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000080</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>EFUSE_DATA0</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>EFUSE_DATA0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EFUSE_DATA1</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>EFUSE_DATA1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EFUSE_DATA2</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>EFUSE_DATA2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EFUSE_DATA3</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>EFUSE_DATA3</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>GPIO</name>
+            <baseAddress>0x60000300</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x000003a0</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>GPIO_OUT</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>BT-Coexist Selection register</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_BT_SEL</name>
+                            <description>BT-Coexist Selection register</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_OUT_DATA</name>
+                            <description>The output value when the GPIO pin is set as output.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_OUT_W1TS</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>GPIO_OUT_W1TS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_OUT_DATA_W1TS</name>
+                            <description>Writing 1 into a bit in this register will set the related bit in
+                                GPIO_OUT_DATA
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_OUT_W1TC</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>GPIO_OUT_W1TC</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_OUT_DATA_W1TC</name>
+                            <description>Writing 1 into a bit in this register will clear the related bit in
+                                GPIO_OUT_DATA
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_ENABLE</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>GPIO_ENABLE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_SDIO_SEL</name>
+                            <description>SDIO-dis selection register</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_ENABLE_DATA</name>
+                            <description>The output enable register.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_ENABLE_W1TS</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>GPIO_ENABLE_W1TS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_ENABLE_DATA_W1TS</name>
+                            <description>Writing 1 into a bit in this register will set the related bit in
+                                GPIO_ENABLE_DATA
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_ENABLE_W1TC</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>GPIO_ENABLE_W1TC</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_ENABLE_DATA_W1TC</name>
+                            <description>Writing 1 into a bit in this register will clear the related bit in
+                                GPIO_ENABLE_DATA
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_IN</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>The values of the strapping pins.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_STRAPPING</name>
+                            <description>The values of the strapping pins.</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_IN_DATA</name>
+                            <description>The values of the GPIO pins when the GPIO pin is set as input.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_STATUS</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>GPIO_STATUS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_STATUS_INTERRUPT</name>
+                            <description>Interrupt enable register.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_STATUS_W1TS</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>GPIO_STATUS_W1TS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_STATUS_INTERRUPT_W1TS</name>
+                            <description>Writing 1 into a bit in this register will set the related bit in
+                                GPIO_STATUS_INTERRUPT
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_STATUS_W1TC</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>GPIO_STATUS_W1TC</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_STATUS_INTERRUPT_W1TC</name>
+                            <description>Writing 1 into a bit in this register will clear the related bit in
+                                GPIO_STATUS_INTERRUPT
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN0</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>GPIO_PIN0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN0_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN0_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN0_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN0_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN0_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN0_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN0_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN1</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>GPIO_PIN1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN1_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN1_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN1_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN1_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN1_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN1_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN1_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN2</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>GPIO_PIN2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN2_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN2_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN2_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN2_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN2_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN2_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN2_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN3</name>
+                    <addressOffset>0x34</addressOffset>
+                    <description>GPIO_PIN3</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN3_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN3_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN3_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN3_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN3_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN3_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN3_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN4</name>
+                    <addressOffset>0x38</addressOffset>
+                    <description>GPIO_PIN4</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN4_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN4_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN4_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN4_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN4_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN4_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN4_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN5</name>
+                    <addressOffset>0x3c</addressOffset>
+                    <description>GPIO_PIN5</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN5_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN5_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN5_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN5_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN5_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN5_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN5_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN6</name>
+                    <addressOffset>0x40</addressOffset>
+                    <description>GPIO_PIN6</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN6_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN6_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN6_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN6_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN6_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN6_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN6_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN7</name>
+                    <addressOffset>0x44</addressOffset>
+                    <description>GPIO_PIN7</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN7_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN7_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN7_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN7_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN7_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN7_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN7_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN8</name>
+                    <addressOffset>0x48</addressOffset>
+                    <description>GPIO_PIN8</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN8_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN8_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN8_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN8_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN8_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN8_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN8_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN9</name>
+                    <addressOffset>0x4c</addressOffset>
+                    <description>GPIO_PIN9</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN9_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN9_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN9_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN9_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN9_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN9_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN9_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN10</name>
+                    <addressOffset>0x50</addressOffset>
+                    <description>GPIO_PIN10</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN10_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN10_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN10_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN10_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN10_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN10_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN10_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN11</name>
+                    <addressOffset>0x54</addressOffset>
+                    <description>GPIO_PIN11</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN11_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN11_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN11_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN11_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN11_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN11_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN11_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN12</name>
+                    <addressOffset>0x58</addressOffset>
+                    <description>GPIO_PIN12</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN12_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN12_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN12_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN12_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN12_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN12_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN12_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN13</name>
+                    <addressOffset>0x5c</addressOffset>
+                    <description>GPIO_PIN13</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN13_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN13_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN13_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN13_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN13_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN13_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN13_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN14</name>
+                    <addressOffset>0x60</addressOffset>
+                    <description>GPIO_PIN14</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN14_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN14_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN14_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN14_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN14_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN14_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN14_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_PIN15</name>
+                    <addressOffset>0x64</addressOffset>
+                    <description>GPIO_PIN15</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>GPIO_PIN15_WAKEUP_ENABLE</name>
+                            <description>0: disable; 1: enable GPIO wakeup CPU, only when GPIO_PIN0_INT_TYPE is 0x4 or
+                                0x5
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GPIO_PIN15_INT_TYPE</name>
+                            <description>0: disable; 1: positive edge; 2: negative edge; 3: both types of edge; 4:
+                                low-level; 5: high-level
+                            </description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN15_INT_TYPE</name><usage>read-write</usage><enumeratedValue><name>disabled</name><description>interrupt is disabled</description><value>0</value></enumeratedValue><enumeratedValue><name>positive_edge</name><description>interrupt is triggered on the positive edge</description><value>1</value></enumeratedValue><enumeratedValue><name>negative_edge</name><description>interrupt is triggered on the negative edge</description><value>2</value></enumeratedValue><enumeratedValue><name>both_edges</name><description>interrupt is triggered on both edges</description><value>3</value></enumeratedValue><enumeratedValue><name>low_level</name><description>interrupt is triggered on the low level</description><value>4</value></enumeratedValue><enumeratedValue><name>high_level</name><description>interrupt is triggered on the high level</description><value>5</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN15_DRIVER</name>
+                            <description>1: open drain; 0: normal</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN15_DRIVER</name><usage>read-write</usage><enumeratedValue><name>open_drain</name><description>open drain</description><value>0</value></enumeratedValue><enumeratedValue><name>normal</name><description>normal</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                        <field>
+                            <name>GPIO_PIN15_SOURCE</name>
+                            <description>1: sigma-delta; 0: GPIO_DATA</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        <enumeratedValues><name>GPIO_PIN15_SOURCE</name><usage>read-write</usage><enumeratedValue><name>sigma_delta</name><description>sigma-delta</description><value>0</value></enumeratedValue><enumeratedValue><name>gpio_data</name><description>gpio data</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_SIGMA_DELTA</name>
+                    <addressOffset>0x68</addressOffset>
+                    <description>GPIO_SIGMA_DELTA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SIGMA_DELTA_ENABLE</name>
+                            <description>1: enable sigma-delta; 0: disable</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SIGMA_DELTA_PRESCALAR</name>
+                            <description>Clock pre-divider for sigma-delta.</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SIGMA_DELTA_TARGET</name>
+                            <description>target level of the sigma-delta. It is a signed byte.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_RTC_CALIB_SYNC</name>
+                    <addressOffset>0x6c</addressOffset>
+                    <description>Positvie edge of this bit will trigger the RTC-clock-calibration process.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>RTC_CALIB_START</name>
+                            <description>Positvie edge of this bit will trigger the RTC-clock-calibration process.
+                            </description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTC_PERIOD_NUM</name>
+                            <description>The cycle number of RTC-clock during RTC-clock-calibration</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>10</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPIO_RTC_CALIB_VALUE</name>
+                    <addressOffset>0x70</addressOffset>
+                    <description>0: during RTC-clock-calibration; 1: RTC-clock-calibration is done</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>RTC_CALIB_RDY</name>
+                            <description>0: during RTC-clock-calibration; 1: RTC-clock-calibration is done</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTC_CALIB_RDY_REAL</name>
+                            <description>0: during RTC-clock-calibration; 1: RTC-clock-calibration is done</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTC_CALIB_VALUE</name>
+                            <description>The cycle number of clk_xtal (crystal clock) for the RTC_PERIOD_NUM cycles of
+                                RTC-clock
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>I2S</name>
+            <baseAddress>0x60000e00</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000160</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>I2STXFIFO</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>I2STXFIFO</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SRXFIFO</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>I2SRXFIFO</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SCONF</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>I2SCONF</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_BCK_DIV_NUM</name>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_CLKM_DIV_NUM</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_BITS_MOD</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_MSB_SHIFT</name>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_MSB_SHIFT</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_START</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_START</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_MSB_RIGHT</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RIGHT_FIRST</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_SLAVE_MOD</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_SLAVE_MOD</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_FIFO_RESET</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_FIFO_RESET</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_RESET</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_RESET</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SINT_RAW</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>I2SINT_RAW</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_TX_REMPTY_INT_RAW</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_WFULL_INT_RAW</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_REMPTY_INT_RAW</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_WFULL_INT_RAW</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_PUT_DATA_INT_RAW</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_TAKE_DATA_INT_RAW</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SINT_ST</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>I2SINT_ST</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_TX_REMPTY_INT_ST</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_WFULL_INT_ST</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_REMPTY_INT_ST</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_WFULL_INT_ST</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_PUT_DATA_INT_ST</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_TAKE_DATA_INT_ST</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SINT_ENA</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>I2SINT_ENA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_TX_REMPTY_INT_ENA</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_WFULL_INT_ENA</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_REMPTY_INT_ENA</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_WFULL_INT_ENA</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_PUT_DATA_INT_ENA</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_TAKE_DATA_INT_ENA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SINT_CLR</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>I2SINT_CLR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_TX_REMPTY_INT_CLR</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_WFULL_INT_CLR</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_REMPTY_INT_CLR</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_WFULL_INT_CLR</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_PUT_DATA_INT_CLR</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TAKE_DATA_INT_CLR</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2STIMING</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>I2STIMING</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_TRANS_BCK_IN_INV</name>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_DSYNC_SW</name>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_DSYNC_SW</name>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_BCK_OUT_DELAY</name>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_WS_OUT_DELAY</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_SD_OUT_DELAY</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_WS_OUT_DELAY</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_BCK_OUT_DELAY</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_SD_IN_DELAY</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_WS_IN_DELAY</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_RECE_BCK_IN_DELAY</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_WS_IN_DELAY</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_TRANS_BCK_IN_DELAY</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2S_FIFO_CONF</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>I2S_FIFO_CONF</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_RX_FIFO_MOD</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_FIFO_MOD</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_DSCR_EN</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_TX_DATA_NUM</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>I2S_I2S_RX_DATA_NUM</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SRXEOF_NUM</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>I2SRXEOF_NUM</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_RX_EOF_NUM</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>I2SCONF_SIGLE_DATA</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>I2SCONF_SIGLE_DATA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>I2S_I2S_SIGLE_DATA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>IO_MUX</name>
+            <baseAddress>0x60000800</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000220</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>IO_MUX_CONF</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>IO_MUX_CONF</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SPI0_CLK_EQU_SYS_CLK</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SPI1_CLK_EQU_SYS_CLK</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_MTDI</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>IO_MUX_MTDI</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_MTCK</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>IO_MUX_MTCK</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_MTMS</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>IO_MUX_MTMS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_MTDO</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>IO_MUX_MTDO</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_U0RXD</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>IO_MUX_U0RXD</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_U0TXD</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>IO_MUX_U0TXD</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_CLK</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>IO_MUX_SD_CLK</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_DATA0</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>IO_MUX_SD_DATA0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_DATA1</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>IO_MUX_SD_DATA1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_DATA2</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>IO_MUX_SD_DATA2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_DATA3</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>IO_MUX_SD_DATA3</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_SD_CMD</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>IO_MUX_SD_CMD</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_GPIO0</name>
+                    <addressOffset>0x34</addressOffset>
+                    <description>IO_MUX_GPIO0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_GPIO2</name>
+                    <addressOffset>0x38</addressOffset>
+                    <description>IO_MUX_GPIO2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_GPIO4</name>
+                    <addressOffset>0x3c</addressOffset>
+                    <description>IO_MUX_GPIO4</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>IO_MUX_GPIO5</name>
+                    <addressOffset>0x40</addressOffset>
+                    <description>IO_MUX_GPIO5</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>FUNCTION_SELECT_LOW_BITS</name><description>configures IO_MUX function, bottom 2 bits</description><bitOffset>4</bitOffset><bitWidth>2</bitWidth></field>
+            <field><name>FUNCTION_SELECT_HIGH_BIT</name><description>configures IO_MUX function, upper bit</description><bitOffset>8</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>PULLUP</name><description>configures pull up</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_PULLUP</name><description>configures pull up during sleep mode</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>SLEEP_ENABLE</name><description>configures output enable during sleep mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>RTC</name>
+            <baseAddress>0x60000700</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000040</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>RTC_STORE0</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>RTC_STORE0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>RTC_STATE1</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>RTC_STATE1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>SLC</name>
+            <baseAddress>0x60000b00</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000400</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SLC_CONF0</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>SLC_CONF0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_MODE</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_DATA_BURST_EN</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_DSCR_BURST_EN</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_NO_RESTART_CLR</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_AUTO_WRBACK</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_LOOP_TEST</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_LOOP_TEST</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_AHBM_RST</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_AHBM_FIFO_RST</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXLINK_RST</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXLINK_RST</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_INT_RAW</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>SLC_INT_RAW</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_DSCR_EMPTY_INT_RAW</name>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DSCR_ERR_INT_RAW</name>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DSCR_ERR_INT_RAW</name>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOHOST_INT_RAW</name>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_EOF_INT_RAW</name>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DONE_INT_RAW</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_EOF_INT_RAW</name>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DONE_INT_RAW</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_1TO0_INT_RAW</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_1TO0_INT_RAW</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_OVF_INT_RAW</name>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_UDF_INT_RAW</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_START_INT_RAW</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_START_INT_RAW</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT7_INT_RAW</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT6_INT_RAW</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT5_INT_RAW</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT4_INT_RAW</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT3_INT_RAW</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT2_INT_RAW</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT1_INT_RAW</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT0_INT_RAW</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_INT_STATUS</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>SLC_INT_STATUS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_DSCR_EMPTY_INT_ST</name>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DSCR_ERR_INT_ST</name>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DSCR_ERR_INT_ST</name>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOHOST_INT_ST</name>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_EOF_INT_ST</name>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DONE_INT_ST</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_EOF_INT_ST</name>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DONE_INT_ST</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_1TO0_INT_ST</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_1TO0_INT_ST</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_OVF_INT_ST</name>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_UDF_INT_ST</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_START_INT_ST</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_START_INT_ST</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT7_INT_ST</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT6_INT_ST</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT5_INT_ST</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT4_INT_ST</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT3_INT_ST</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT2_INT_ST</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT1_INT_ST</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT0_INT_ST</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_INT_ENA</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>SLC_INT_ENA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_DSCR_EMPTY_INT_ENA</name>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DSCR_ERR_INT_ENA</name>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DSCR_ERR_INT_ENA</name>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOHOST_INT_ENA</name>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_EOF_INT_ENA</name>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DONE_INT_ENA</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_EOF_INT_ENA</name>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DONE_INT_ENA</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_1TO0_INT_ENA</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_1TO0_INT_ENA</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_OVF_INT_ENA</name>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_UDF_INT_ENA</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_START_INT_ENA</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_START_INT_ENA</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT7_INT_ENA</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT6_INT_ENA</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT5_INT_ENA</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT4_INT_ENA</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT3_INT_ENA</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT2_INT_ENA</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT1_INT_ENA</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT0_INT_ENA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_INT_CLR</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>SLC_INT_CLR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_DSCR_EMPTY_INT_CLR</name>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DSCR_ERR_INT_CLR</name>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DSCR_ERR_INT_CLR</name>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOHOST_INT_CLR</name>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_EOF_INT_CLR</name>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_DONE_INT_CLR</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_EOF_INT_CLR</name>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DONE_INT_CLR</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_1TO0_INT_CLR</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_1TO0_INT_CLR</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_OVF_INT_CLR</name>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_UDF_INT_CLR</name>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_START_INT_CLR</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_START_INT_CLR</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT7_INT_CLR</name>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT6_INT_CLR</name>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT5_INT_CLR</name>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT4_INT_CLR</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT3_INT_CLR</name>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT2_INT_CLR</name>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT1_INT_CLR</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FRHOST_BIT0_INT_CLR</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_STATUS</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>SLC_RX_STATUS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_RX_EMPTY</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RX_FULL</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_FIFO_PUSH</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>SLC_RX_FIFO_PUSH</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_RXFIFO_PUSH</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXFIFO_WDATA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TX_STATUS</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>SLC_TX_STATUS</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_EMPTY</name>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_FULL</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TX_FIFO_POP</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>SLC_TX_FIFO_POP</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TXFIFO_POP</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXFIFO_RDATA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>11</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_LINK</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>SLC_RX_LINK</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_RXLINK_PARK</name>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXLINK_RESTART</name>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXLINK_START</name>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXLINK_STOP</name>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_RXLINK_ADDR</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TX_LINK</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>SLC_TX_LINK</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TXLINK_PARK</name>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXLINK_RESTART</name>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXLINK_START</name>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXLINK_STOP</name>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXLINK_ADDR</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_INTVEC_TOHOST</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>SLC_INTVEC_TOHOST</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TOHOST_INTVEC</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TOKEN0</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>SLC_TOKEN0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TOKEN0</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_LOCAL_INC_MORE</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_LOCAL_INC</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_LOCAL_WR</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN0_LOCAL_WDATA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TOKEN1</name>
+                    <addressOffset>0x34</addressOffset>
+                    <description>SLC_TOKEN1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TOKEN1</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_LOCAL_INC_MORE</name>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_LOCAL_INC</name>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_LOCAL_WR</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN1_LOCAL_WDATA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_CONF1</name>
+                    <addressOffset>0x38</addressOffset>
+                    <description>SLC_CONF1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_STATE0</name>
+                    <addressOffset>0x3c</addressOffset>
+                    <description>SLC_STATE0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_STATE1</name>
+                    <addressOffset>0x40</addressOffset>
+                    <description>SLC_STATE1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_BRIDGE_CONF</name>
+                    <addressOffset>0x44</addressOffset>
+                    <description>SLC_BRIDGE_CONF</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_TX_PUSH_IDLE_NUM</name>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TX_DUMMY_MODE</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FIFO_MAP_ENA</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TXEOF_ENA</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_EOF_DES_ADDR</name>
+                    <addressOffset>0x48</addressOffset>
+                    <description>SLC_RX_EOF_DES_ADDR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TX_EOF_DES_ADDR</name>
+                    <addressOffset>0x4c</addressOffset>
+                    <description>SLC_TX_EOF_DES_ADDR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_EOF_BFR_DES_ADDR</name>
+                    <addressOffset>0x50</addressOffset>
+                    <description>SLC_RX_EOF_BFR_DES_ADDR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_AHB_TEST</name>
+                    <addressOffset>0x54</addressOffset>
+                    <description>SLC_AHB_TEST</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_AHB_TESTADDR</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_AHB_TESTMODE</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_SDIO_ST</name>
+                    <addressOffset>0x58</addressOffset>
+                    <description>SLC_SDIO_ST</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_BUS_ST</name>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_SDIO_WAKEUP</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_FUNC_ST</name>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_CMD_ST</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RX_DSCR_CONF</name>
+                    <addressOffset>0x5c</addressOffset>
+                    <description>SLC_RX_DSCR_CONF</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>SLC_INFOR_NO_REPLACE</name>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLC_TOKEN_NO_REPLACE</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TXLINK_DSCR</name>
+                    <addressOffset>0x60</addressOffset>
+                    <description>SLC_TXLINK_DSCR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TXLINK_DSCR_BF0</name>
+                    <addressOffset>0x64</addressOffset>
+                    <description>SLC_TXLINK_DSCR_BF0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_TXLINK_DSCR_BF1</name>
+                    <addressOffset>0x68</addressOffset>
+                    <description>SLC_TXLINK_DSCR_BF1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RXLINK_DSCR</name>
+                    <addressOffset>0x6c</addressOffset>
+                    <description>SLC_RXLINK_DSCR</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RXLINK_DSCR_BF0</name>
+                    <addressOffset>0x70</addressOffset>
+                    <description>SLC_RXLINK_DSCR_BF0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_RXLINK_DSCR_BF1</name>
+                    <addressOffset>0x74</addressOffset>
+                    <description>SLC_RXLINK_DSCR_BF1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_DATE</name>
+                    <addressOffset>0x78</addressOffset>
+                    <description>SLC_DATE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLC_ID</name>
+                    <addressOffset>0x7c</addressOffset>
+                    <description>SLC_ID</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>SPI0</name>
+            <baseAddress>0x60000200</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000400</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SPI_CMD</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>In the master mode, it is the start bit of a single operation. Self-clear by hardware
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_usr</name>
+                            <description>In the master mode, it is the start bit of a single operation. Self-clear by
+                                hardware
+                            </description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_read</name><bitOffset>31</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_enable</name><bitOffset>30</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_disable</name><bitOffset>29</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_read_id</name><bitOffset>28</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_read_sr</name><bitOffset>27</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_sr</name><bitOffset>26</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_pp</name><bitOffset>25</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_se</name><bitOffset>24</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_be</name><bitOffset>23</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ce</name><bitOffset>22</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_dp</name><bitOffset>21</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_res</name><bitOffset>20</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_hpm</name><bitOffset>19</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_ADDR</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>In the master mode, it is the value of address in "address" phase.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>iodata_start_addr</name>
+                            <description>In the master mode, it is the value of address in "address" phase.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>address</name><bitOffset>0</bitOffset><bitWidth>24</bitWidth></field>
+            <field><name>size</name><bitOffset>24</bitOffset><bitWidth>8</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_CTRL</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>SPI_CTRL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_wr_bit_order</name>
+                            <description>In "command", "address", "write-data" (MOSI) phases, 1: LSB first; 0: MSB
+                                first
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_rd_bit_order</name>
+                            <description>In "read-data" (MISO) phase, 1: LSB first; 0: MSB first</description>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_qio_mode</name>
+                            <description>In the read operations, "address" phase and "read-data" phase apply 4 signals
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_dio_mode</name>
+                            <description>In the read operations, "address" phase and "read-data" phase apply 2 signals
+                            </description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_qout_mode</name>
+                            <description>In the read operations, "read-data" phase apply 4 signals</description>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_dout_mode</name>
+                            <description>In the read operations, "read-data" phase apply 2 signals</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fastrd_mode</name>
+                            <description>this bit enable the bits: spi_qio_mode, spi_dio_mode, spi_qout_mode and
+                                spi_dout_mode
+                            </description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_RD_STATUS</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>In the slave mode, this register are the status register for the master to read out.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_rd_status</name>
+                            <description>In the slave mode, this register are the status register for the master to read
+                                out.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_CTRL2</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>spi_cs signal is delayed by 80MHz clock cycles</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_cs_delay_num</name>
+                            <description>spi_cs signal is delayed by 80MHz clock cycles</description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs_delay_mode</name>
+                            <description>spi_cs signal is delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_mosi_delay_num</name>
+                            <description>MOSI signals are delayed by 80MHz clock cycles</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_mosi_delay_mode</name>
+                            <description>MOSI signals are delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_miso_delay_num</name>
+                            <description>MISO signals are delayed by 80MHz clock cycles</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_miso_delay_mode</name>
+                            <description>MISO signals are delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_CLOCK</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>In the master mode, 1: spi_clk is eqaul to 80MHz, 0: spi_clk is divided from 80 MHz
+                        clock.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_clk_equ_sysclk</name>
+                            <description>In the master mode, 1: spi_clk is eqaul to 80MHz, 0: spi_clk is divided from 80
+                                MHz clock.
+                            </description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkdiv_pre</name>
+                            <description>In the master mode, it is pre-divider of spi_clk.</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>13</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_N</name>
+                            <description>In the master mode, it is the divider of spi_clk. So spi_clk frequency is
+                                80MHz/(spi_clkdiv_pre+1)/(spi_clkcnt_N+1)
+                            </description>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_H</name>
+                            <description>In the master mode, it must be floor((spi_clkcnt_N+1)/2-1). In the slave mode,
+                                it must be 0.
+                            </description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_L</name>
+                            <description>In the master mode, it must be eqaul to spi_clkcnt_N. In the slave mode, it
+                                must be 0.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_USER</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>This bit enable the "command" phase of an operation.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_usr_command</name>
+                            <description>This bit enable the "command" phase of an operation.</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_addr</name>
+                            <description>This bit enable the "address" phase of an operation.</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_dummy</name>
+                            <description>This bit enable the "dummy" phase of an operation.</description>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_miso</name>
+                            <description>This bit enable the "read-data" phase of an operation.</description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_mosi</name>
+                            <description>This bit enable the "write-data" phase of an operation.</description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_mosi_highpart</name>
+                            <description>1: "write-data" phase only access to high-part of the buffer spi_w8~spi_w15
+                            </description>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_miso_highpart</name>
+                            <description>1: "read-data" phase only access to high-part of the buffer spi_w8~spi_w15
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_sio</name>
+                            <description>1: mosi and miso signals share the same pin</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_qio</name>
+                            <description>In the write operations, "address" phase and "read-data" phase apply 4
+                                signals
+                            </description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_dio</name>
+                            <description>In the write operations, "address" phase and "read-data" phase apply 2
+                                signals
+                            </description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_quad</name>
+                            <description>In the write operations, "read-data" phase apply 4 signals</description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_dual</name>
+                            <description>In the write operations, "read-data" phase apply 2 signals</description>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_wr_byte_order</name>
+                            <description>In "command", "address", "write-data" (MOSI) phases, 1: little-endian; 0:
+                                big_endian
+                            </description>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_rd_byte_order</name>
+                            <description>In "read-data" (MISO) phase, 1: little-endian; 0: big_endian</description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_ck_i_edge</name>
+                            <description>In the slave mode, 1: rising-edge; 0: falling-edge</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_ck_o_edge</name><description>In the master mode, 1: rising-edge; 0: falling-edge</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_cs_setup</name><description>spi cs is enable when spi is in prepare phase. 1: enable 0: disable.</description><bitOffset>5</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_cs_hold</name><description>spi cs keep low when spi is in done phase. 1: enable 0: disable.</description><bitOffset>4</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ahb_user_command</name><description>reserved</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_flash_mode</name><bitOffset>2</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ahb_user_command_4byte</name><description>reserved</description><bitOffset>1</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_duplex</name><description>set spi in full duplex mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_USER1</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>The length in bits of "address" phase. The register value shall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_usr_addr_bitlen</name>
+                            <description>The length in bits of "address" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_mosi_bitlen</name>
+                            <description>The length in bits of "write-data" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_miso_bitlen</name>
+                            <description>The length in bits of "read-data" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_dummy_cyclelen</name>
+                            <description>The length in spi_clk cycles of "dummy" phase. The register value shall be
+                                (cycle_num-1)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_USER2</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>The length in bits of "command" phase. The register value shall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_usr_command_bitlen</name>
+                            <description>The length in bits of "command" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_command_value</name>
+                            <description>The value of "command" phase</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_WR_STATUS</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>In the slave mode, this register are the status register for the master to write
+                        into.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wr_status</name>
+                            <description>In the slave mode, this register are the status register for the master to
+                                write into.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_PIN</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>1: disable CS2; 0: spi_cs signal is from/to CS2 pin</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_cs2_dis</name>
+                            <description>1: disable CS2; 0: spi_cs signal is from/to CS2 pin</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs1_dis</name>
+                            <description>1: disable CS1; 0: spi_cs signal is from/to CS1 pin</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs0_dis</name>
+                            <description>1: disable CS0; 0: spi_cs signal is from/to CS0 pin</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_idle_edge</name><description>In the master mode, 1: high when idle; 0: low when idle</description><bitOffset>29</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>It is the synchronous reset signal of the module. This bit is self-cleared by
+                        hardware.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_sync_reset</name>
+                            <description>It is the synchronous reset signal of the module. This bit is self-cleared by
+                                hardware.
+                            </description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_slave_mode</name>
+                            <description>1: slave mode, 0: master mode.</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_cmd_define</name>
+                            <description>1: slave mode commands are defined in SPI_SLAVE3. 0: slave mode commands are
+                                fixed as 1: "write-status"; 4: "read-status"; 2: "write-buffer" and 3: "read-buffer".
+                            </description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_trans_cnt</name>
+                            <description>The operations counter in both the master mode and the slave mode.
+                            </description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>spi_int_en</name>
+                            <description>Interrupt enable bits for the below 5 sources</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_trans_done</name>
+                            <description>The interrupt raw bit for the completement of any operation in both the master
+                                mode and the slave mode.
+                            </description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_sta_done</name>
+                            <description>The interrupt raw bit for the completement of "write-status" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_sta_done</name>
+                            <description>The interrupt raw bit for the completement of "read-status" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_buf_done</name>
+                            <description>The interrupt raw bit for the completement of "write-buffer" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_buf_done</name>
+                            <description>The interrupt raw bit for the completement of "read-buffer" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE1</name>
+                    <addressOffset>0x34</addressOffset>
+                    <description>In the slave mode, it is the length in bits for "write-status" and "read-status"
+                        operations. The register valueshall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_status_bitlen</name>
+                            <description>In the slave mode, it is the length in bits for "write-status" and
+                                "read-status" operations. The register valueshall be (bit_num-1)
+                            </description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_buf_bitlen</name>
+                            <description>In the slave mode, it is the length in bits for "write-buffer" and
+                                "read-buffer" operations. The register value shallbe (bit_num-1)
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_addr_bitlen</name>
+                            <description>In the slave mode, it is the address length in bits for "read-buffer"
+                                operation. The register value shall be(bit_num-1)
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_addr_bitlen</name>
+                            <description>In the slave mode, it is the address length in bits for "write-buffer"
+                                operation. The register value shall be(bit_num-1)
+                            </description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrsta_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "write-status"
+                                operations.
+                            </description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "read-status"
+                                operations.
+                            </description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrbuf_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "write-buffer"
+                                operations.
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "read-buffer"
+                                operations.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE2</name>
+                    <addressOffset>0x38</addressOffset>
+                    <description>In the slave mode, it is the length in spi_clk cycles "dummy" phase for "write-buffer"
+                        operations. The registervalue shall be (cycle_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wrbuf_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles "dummy" phase for
+                                "write-buffer" operations. The registervalue shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "read-buffer" operations. The registervalue shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrsta_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "write-status" operations. Theregister value shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "read-status" operations. Theregister value shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE3</name>
+                    <addressOffset>0x3c</addressOffset>
+                    <description>In slave mode, it is the value of "write-status" command</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wrsta_cmd_value</name>
+                            <description>In slave mode, it is the value of "write-status" command</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_cmd_value</name>
+                            <description>In slave mode, it is the value of "read-status" command</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrbuf_cmd_value</name>
+                            <description>In slave mode, it is the value of "write-buffer" command</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_cmd_value</name>
+                            <description>In slave mode, it is the value of "read-buffer" command</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_EXT3</name>
+                    <addressOffset>0xfc</addressOffset>
+                    <description>This register is for two SPI masters to share the same cs, clock and data signals.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_int_hold_ena</name>
+                            <description>This register is for two SPI masters to share the same cs, clock and data
+                                signals.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W0</name>
+                    <addressOffset>0x40</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w0</name>
+                            <description>the data inside the buffer of the SPI module, byte 0</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W1</name>
+                    <addressOffset>0x60</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w1</name>
+                            <description>the data inside the buffer of the SPI module, byte 1</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W2</name>
+                    <addressOffset>0x80</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w2</name>
+                            <description>the data inside the buffer of the SPI module, byte 2</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W3</name>
+                    <addressOffset>0xa0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 3</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w3</name>
+                            <description>the data inside the buffer of the SPI module, byte 3</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W4</name>
+                    <addressOffset>0xc0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 4</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w4</name>
+                            <description>the data inside the buffer of the SPI module, byte 4</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W5</name>
+                    <addressOffset>0xe0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 5</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w5</name>
+                            <description>the data inside the buffer of the SPI module, byte 5</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W6</name>
+                    <addressOffset>0x100</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 6</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w6</name>
+                            <description>the data inside the buffer of the SPI module, byte 6</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W7</name>
+                    <addressOffset>0x120</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 7</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w7</name>
+                            <description>the data inside the buffer of the SPI module, byte 7</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W8</name>
+                    <addressOffset>0x140</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 8</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w8</name>
+                            <description>the data inside the buffer of the SPI module, byte 8</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W9</name>
+                    <addressOffset>0x160</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 9</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w9</name>
+                            <description>the data inside the buffer of the SPI module, byte 9</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W10</name>
+                    <addressOffset>0x180</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 10</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w10</name>
+                            <description>the data inside the buffer of the SPI module, byte 10</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W11</name>
+                    <addressOffset>0x1a0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 11</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w11</name>
+                            <description>the data inside the buffer of the SPI module, byte 11</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W12</name>
+                    <addressOffset>0x1c0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 12</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w12</name>
+                            <description>the data inside the buffer of the SPI module, byte 12</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W13</name>
+                    <addressOffset>0x1e0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 13</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w13</name>
+                            <description>the data inside the buffer of the SPI module, byte 13</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W14</name>
+                    <addressOffset>0x200</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 14</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w14</name>
+                            <description>the data inside the buffer of the SPI module, byte 14</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W15</name>
+                    <addressOffset>0x220</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 15</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w15</name>
+                            <description>the data inside the buffer of the SPI module, byte 15</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            <register><name>SPI_CTRL1</name><fields><field><name>status</name><description>In the slave mode, it is the status for master to read out.</description><bitOffset>0</bitOffset><bitWidth>16</bitWidth></field>
+            <field><name>wb_mode</name><description>Mode bits in the flash fast read mode, it is combined with spi_fastrd_mode bit.</description><bitOffset>16</bitOffset><bitWidth>8</bitWidth></field>
+            <field><name>status_ext</name><description>In the slave mode,it is the status for master to read out.</description><bitOffset>24</bitOffset><bitWidth>8</bitWidth></field>
+            </fields><addressOffset>12</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        </registers>
+        </peripheral>
+        <peripheral>
+            <name>SPI1</name>
+            <baseAddress>0x60000100</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000400</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SPI_CMD</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>In the master mode, it is the start bit of a single operation. Self-clear by hardware
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_usr</name>
+                            <description>In the master mode, it is the start bit of a single operation. Self-clear by
+                                hardware
+                            </description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_read</name><bitOffset>31</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_enable</name><bitOffset>30</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_disable</name><bitOffset>29</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_read_id</name><bitOffset>28</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_read_sr</name><bitOffset>27</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_write_sr</name><bitOffset>26</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_pp</name><bitOffset>25</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_se</name><bitOffset>24</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_be</name><bitOffset>23</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ce</name><bitOffset>22</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_dp</name><bitOffset>21</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_res</name><bitOffset>20</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_hpm</name><bitOffset>19</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_ADDR</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>In the master mode, it is the value of address in "address" phase.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>iodata_start_addr</name>
+                            <description>In the master mode, it is the value of address in "address" phase.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>address</name><bitOffset>0</bitOffset><bitWidth>24</bitWidth></field>
+            <field><name>size</name><bitOffset>24</bitOffset><bitWidth>8</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_CTRL</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>SPI_CTRL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_wr_bit_order</name>
+                            <description>In "command", "address", "write-data" (MOSI) phases, 1: LSB first; 0: MSB
+                                first
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_rd_bit_order</name>
+                            <description>In "read-data" (MISO) phase, 1: LSB first; 0: MSB first</description>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_qio_mode</name>
+                            <description>In the read operations, "address" phase and "read-data" phase apply 4 signals
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_dio_mode</name>
+                            <description>In the read operations, "address" phase and "read-data" phase apply 2 signals
+                            </description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_qout_mode</name>
+                            <description>In the read operations, "read-data" phase apply 4 signals</description>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_dout_mode</name>
+                            <description>In the read operations, "read-data" phase apply 2 signals</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fastrd_mode</name>
+                            <description>this bit enable the bits: spi_qio_mode, spi_dio_mode, spi_qout_mode and
+                                spi_dout_mode
+                            </description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_RD_STATUS</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>In the slave mode, this register are the status register for the master to read out.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_rd_status</name>
+                            <description>In the slave mode, this register are the status register for the master to read
+                                out.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_CTRL2</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>spi_cs signal is delayed by 80MHz clock cycles</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_cs_delay_num</name>
+                            <description>spi_cs signal is delayed by 80MHz clock cycles</description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs_delay_mode</name>
+                            <description>spi_cs signal is delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_mosi_delay_num</name>
+                            <description>MOSI signals are delayed by 80MHz clock cycles</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_mosi_delay_mode</name>
+                            <description>MOSI signals are delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_miso_delay_num</name>
+                            <description>MISO signals are delayed by 80MHz clock cycles</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_miso_delay_mode</name>
+                            <description>MISO signals are delayed by spi_clk. 0: zero; 1: half cycle; 2: one cycle
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_CLOCK</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>In the master mode, 1: spi_clk is eqaul to 80MHz, 0: spi_clk is divided from 80 MHz
+                        clock.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_clk_equ_sysclk</name>
+                            <description>In the master mode, 1: spi_clk is eqaul to 80MHz, 0: spi_clk is divided from 80
+                                MHz clock.
+                            </description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkdiv_pre</name>
+                            <description>In the master mode, it is pre-divider of spi_clk.</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>13</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_N</name>
+                            <description>In the master mode, it is the divider of spi_clk. So spi_clk frequency is
+                                80MHz/(spi_clkdiv_pre+1)/(spi_clkcnt_N+1)
+                            </description>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_H</name>
+                            <description>In the master mode, it must be floor((spi_clkcnt_N+1)/2-1). In the slave mode,
+                                it must be 0.
+                            </description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_clkcnt_L</name>
+                            <description>In the master mode, it must be eqaul to spi_clkcnt_N. In the slave mode, it
+                                must be 0.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_USER</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>This bit enable the "command" phase of an operation.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_usr_command</name>
+                            <description>This bit enable the "command" phase of an operation.</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_addr</name>
+                            <description>This bit enable the "address" phase of an operation.</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_dummy</name>
+                            <description>This bit enable the "dummy" phase of an operation.</description>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_miso</name>
+                            <description>This bit enable the "read-data" phase of an operation.</description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_usr_mosi</name>
+                            <description>This bit enable the "write-data" phase of an operation.</description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_mosi_highpart</name>
+                            <description>1: "write-data" phase only access to high-part of the buffer spi_w8~spi_w15
+                            </description>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_miso_highpart</name>
+                            <description>1: "read-data" phase only access to high-part of the buffer spi_w8~spi_w15
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_sio</name>
+                            <description>1: mosi and miso signals share the same pin</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_qio</name>
+                            <description>In the write operations, "address" phase and "read-data" phase apply 4
+                                signals
+                            </description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_dio</name>
+                            <description>In the write operations, "address" phase and "read-data" phase apply 2
+                                signals
+                            </description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_quad</name>
+                            <description>In the write operations, "read-data" phase apply 4 signals</description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_fwrite_dual</name>
+                            <description>In the write operations, "read-data" phase apply 2 signals</description>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_wr_byte_order</name>
+                            <description>In "command", "address", "write-data" (MOSI) phases, 1: little-endian; 0:
+                                big_endian
+                            </description>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_rd_byte_order</name>
+                            <description>In "read-data" (MISO) phase, 1: little-endian; 0: big_endian</description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_ck_i_edge</name>
+                            <description>In the slave mode, 1: rising-edge; 0: falling-edge</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_ck_o_edge</name><description>In the master mode, 1: rising-edge; 0: falling-edge</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_cs_setup</name><description>spi cs is enable when spi is in prepare phase. 1: enable 0: disable.</description><bitOffset>5</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_cs_hold</name><description>spi cs keep low when spi is in done phase. 1: enable 0: disable.</description><bitOffset>4</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ahb_user_command</name><description>reserved</description><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_flash_mode</name><bitOffset>2</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_ahb_user_command_4byte</name><description>reserved</description><bitOffset>1</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>spi_duplex</name><description>set spi in full duplex mode</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_USER1</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>The length in bits of "address" phase. The register value shall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_usr_addr_bitlen</name>
+                            <description>The length in bits of "address" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_mosi_bitlen</name>
+                            <description>The length in bits of "write-data" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_miso_bitlen</name>
+                            <description>The length in bits of "read-data" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_dummy_cyclelen</name>
+                            <description>The length in spi_clk cycles of "dummy" phase. The register value shall be
+                                (cycle_num-1)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_USER2</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>The length in bits of "command" phase. The register value shall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_usr_command_bitlen</name>
+                            <description>The length in bits of "command" phase. The register value shall be
+                                (bit_num-1)
+                            </description>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>reg_usr_command_value</name>
+                            <description>The value of "command" phase</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_WR_STATUS</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>In the slave mode, this register are the status register for the master to write
+                        into.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wr_status</name>
+                            <description>In the slave mode, this register are the status register for the master to
+                                write into.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_PIN</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>1: disable CS2; 0: spi_cs signal is from/to CS2 pin</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_cs2_dis</name>
+                            <description>1: disable CS2; 0: spi_cs signal is from/to CS2 pin</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs1_dis</name>
+                            <description>1: disable CS1; 0: spi_cs signal is from/to CS1 pin</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_cs0_dis</name>
+                            <description>1: disable CS0; 0: spi_cs signal is from/to CS0 pin</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>spi_idle_edge</name><description>In the master mode, 1: high when idle; 0: low when idle</description><bitOffset>29</bitOffset><bitWidth>1</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>It is the synchronous reset signal of the module. This bit is self-cleared by
+                        hardware.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_sync_reset</name>
+                            <description>It is the synchronous reset signal of the module. This bit is self-cleared by
+                                hardware.
+                            </description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_slave_mode</name>
+                            <description>1: slave mode, 0: master mode.</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_cmd_define</name>
+                            <description>1: slave mode commands are defined in SPI_SLAVE3. 0: slave mode commands are
+                                fixed as 1: "write-status"; 4: "read-status"; 2: "write-buffer" and 3: "read-buffer".
+                            </description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_trans_cnt</name>
+                            <description>The operations counter in both the master mode and the slave mode.
+                            </description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>spi_int_en</name>
+                            <description>Interrupt enable bits for the below 5 sources</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>spi_trans_done</name>
+                            <description>The interrupt raw bit for the completement of any operation in both the master
+                                mode and the slave mode.
+                            </description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_sta_done</name>
+                            <description>The interrupt raw bit for the completement of "write-status" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_sta_done</name>
+                            <description>The interrupt raw bit for the completement of "read-status" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_buf_done</name>
+                            <description>The interrupt raw bit for the completement of "write-buffer" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_buf_done</name>
+                            <description>The interrupt raw bit for the completement of "read-buffer" operation in the
+                                slave mode.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE1</name>
+                    <addressOffset>0x34</addressOffset>
+                    <description>In the slave mode, it is the length in bits for "write-status" and "read-status"
+                        operations. The register valueshall be (bit_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_status_bitlen</name>
+                            <description>In the slave mode, it is the length in bits for "write-status" and
+                                "read-status" operations. The register valueshall be (bit_num-1)
+                            </description>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_buf_bitlen</name>
+                            <description>In the slave mode, it is the length in bits for "write-buffer" and
+                                "read-buffer" operations. The register value shallbe (bit_num-1)
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rd_addr_bitlen</name>
+                            <description>In the slave mode, it is the address length in bits for "read-buffer"
+                                operation. The register value shall be(bit_num-1)
+                            </description>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wr_addr_bitlen</name>
+                            <description>In the slave mode, it is the address length in bits for "write-buffer"
+                                operation. The register value shall be(bit_num-1)
+                            </description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrsta_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "write-status"
+                                operations.
+                            </description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "read-status"
+                                operations.
+                            </description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrbuf_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "write-buffer"
+                                operations.
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_dummy_en</name>
+                            <description>In the slave mode, it is the enable bit of "dummy" phase for "read-buffer"
+                                operations.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE2</name>
+                    <addressOffset>0x38</addressOffset>
+                    <description>In the slave mode, it is the length in spi_clk cycles "dummy" phase for "write-buffer"
+                        operations. The registervalue shall be (cycle_num-1)
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wrbuf_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles "dummy" phase for
+                                "write-buffer" operations. The registervalue shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "read-buffer" operations. The registervalue shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrsta_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "write-status" operations. Theregister value shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_dummy_cyclelen</name>
+                            <description>In the slave mode, it is the length in spi_clk cycles of "dummy" phase for
+                                "read-status" operations. Theregister value shall be (cycle_num-1)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_SLAVE3</name>
+                    <addressOffset>0x3c</addressOffset>
+                    <description>In slave mode, it is the value of "write-status" command</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>slv_wrsta_cmd_value</name>
+                            <description>In slave mode, it is the value of "write-status" command</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdsta_cmd_value</name>
+                            <description>In slave mode, it is the value of "read-status" command</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_wrbuf_cmd_value</name>
+                            <description>In slave mode, it is the value of "write-buffer" command</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>slv_rdbuf_cmd_value</name>
+                            <description>In slave mode, it is the value of "read-buffer" command</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_EXT3</name>
+                    <addressOffset>0xfc</addressOffset>
+                    <description>This register is for two SPI masters to share the same cs, clock and data signals.
+                    </description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>reg_int_hold_ena</name>
+                            <description>This register is for two SPI masters to share the same cs, clock and data
+                                signals.
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W0</name>
+                    <addressOffset>0x40</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 0</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w0</name>
+                            <description>the data inside the buffer of the SPI module, byte 0</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W1</name>
+                    <addressOffset>0x60</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 1</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w1</name>
+                            <description>the data inside the buffer of the SPI module, byte 1</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W2</name>
+                    <addressOffset>0x80</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 2</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w2</name>
+                            <description>the data inside the buffer of the SPI module, byte 2</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W3</name>
+                    <addressOffset>0xa0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 3</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w3</name>
+                            <description>the data inside the buffer of the SPI module, byte 3</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W4</name>
+                    <addressOffset>0xc0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 4</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w4</name>
+                            <description>the data inside the buffer of the SPI module, byte 4</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W5</name>
+                    <addressOffset>0xe0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 5</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w5</name>
+                            <description>the data inside the buffer of the SPI module, byte 5</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W6</name>
+                    <addressOffset>0x100</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 6</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w6</name>
+                            <description>the data inside the buffer of the SPI module, byte 6</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W7</name>
+                    <addressOffset>0x120</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 7</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w7</name>
+                            <description>the data inside the buffer of the SPI module, byte 7</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W8</name>
+                    <addressOffset>0x140</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 8</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w8</name>
+                            <description>the data inside the buffer of the SPI module, byte 8</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W9</name>
+                    <addressOffset>0x160</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 9</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w9</name>
+                            <description>the data inside the buffer of the SPI module, byte 9</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W10</name>
+                    <addressOffset>0x180</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 10</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w10</name>
+                            <description>the data inside the buffer of the SPI module, byte 10</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W11</name>
+                    <addressOffset>0x1a0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 11</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w11</name>
+                            <description>the data inside the buffer of the SPI module, byte 11</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W12</name>
+                    <addressOffset>0x1c0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 12</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w12</name>
+                            <description>the data inside the buffer of the SPI module, byte 12</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W13</name>
+                    <addressOffset>0x1e0</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 13</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w13</name>
+                            <description>the data inside the buffer of the SPI module, byte 13</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W14</name>
+                    <addressOffset>0x200</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 14</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w14</name>
+                            <description>the data inside the buffer of the SPI module, byte 14</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SPI_W15</name>
+                    <addressOffset>0x220</addressOffset>
+                    <description>the data inside the buffer of the SPI module, byte 15</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>spi_w15</name>
+                            <description>the data inside the buffer of the SPI module, byte 15</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            <register><name>SPI_CTRL1</name><fields><field><name>status</name><description>In the slave mode, it is the status for master to read out.</description><bitOffset>0</bitOffset><bitWidth>16</bitWidth></field>
+            <field><name>wb_mode</name><description>Mode bits in the flash fast read mode, it is combined with spi_fastrd_mode bit.</description><bitOffset>16</bitOffset><bitWidth>8</bitWidth></field>
+            <field><name>status_ext</name><description>In the slave mode,it is the status for master to read out.</description><bitOffset>24</bitOffset><bitWidth>8</bitWidth></field>
+            </fields><addressOffset>12</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        </registers>
+        </peripheral>
+        <peripheral>
+            <name>TIMER</name>
+            <baseAddress>0x60000600</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000120</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>FRC1_LOAD</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>the load value into the counter</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc1_load_value</name>
+                            <description>the load value into the counter</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>23</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC1_COUNT</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>the current value of the counter. It is a decreasingcounter.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc1_count</name>
+                            <description>the current value of the counter. It is a decreasingcounter.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>23</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC1_CTRL</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>FRC1_CTRL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc1_int</name>
+                            <description>the status of the interrupt, when the count isdereased to zero</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frc1_ctrl</name>
+                            <description>bit[7]: timer enable, bit[6]: automatically reload, when the counter isequal to
+                                zero, bit[3:2]: prescale-divider, 0: divided by 1, 1: dividedby 16, 2 or 3: divided by
+                                256, bit[0]: interrupt type, 0:edge, 1:level
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>timer_enable</name><description>Enable or disable the timer</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth><access>read-write</access></field>
+            <field><name>rollover</name><description>Automatically reload when the counter hits zero</description><bitOffset>6</bitOffset><bitWidth>1</bitWidth><access>read-write</access></field>
+            <field><name>prescale_divider</name><description>Pre-scale divider for the timer</description><bitOffset>2</bitOffset><bitWidth>2</bitWidth><access>read-write</access><enumeratedValues><name>prescale_divider</name><usage>read-write</usage><enumeratedValue><name>devided_by_1</name><description>divided by 1</description><value>0</value></enumeratedValue><enumeratedValue><name>devided_by_16</name><description>divided by 16</description><value>1</value></enumeratedValue><enumeratedValue><name>devided_by_256</name><description>divided by 256</description><value>2</value></enumeratedValue></enumeratedValues>
+            </field>
+            <field><name>interrupt_type</name><description>Configure the interrupt type</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth><access>read-write</access><enumeratedValues><name>interrupt_type</name><usage>read-write</usage><enumeratedValue><name>edge</name><description>edge</description><value>0</value></enumeratedValue><enumeratedValue><name>level</name><description>level</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+            </fields>
+                </register>
+                <register>
+                    <name>FRC1_INT</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>FRC1_INT</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc1_int_clr_mask</name>
+                            <description>write to clear the status of the interrupt, if theinterrupt type is "level"
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC2_LOAD</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>the load value into the counter</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc2_load_value</name>
+                            <description>the load value into the counter</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC2_COUNT</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>the current value of the counter. It is a increasingcounter.</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc2_count</name>
+                            <description>the current value of the counter. It is a increasingcounter.</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC2_CTRL</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>FRC2_CTRL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc2_int</name>
+                            <description>the status of the interrupt, when the count is equal tothe alarm value
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frc2_ctrl</name>
+                            <description>bit[7]: timer enable, bit[6]: automatically reload, when the counter isequal to
+                                zero, bit[3:2]: prescale-divider, 0: divided by 1, 1: dividedby 16, 2 or 3: divided by
+                                256, bit[0]: interrupt type, 0:edge, 1:level
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    <field><name>timer_enable</name><description>Enable or disable the timer</description><bitOffset>7</bitOffset><bitWidth>1</bitWidth><access>read-write</access></field>
+            <field><name>rollover</name><description>Automatically reload when the counter hits zero</description><bitOffset>6</bitOffset><bitWidth>1</bitWidth><access>read-write</access></field>
+            <field><name>prescale_divider</name><description>Pre-scale divider for the timer</description><bitOffset>2</bitOffset><bitWidth>2</bitWidth><access>read-write</access><enumeratedValues><name>prescale_divider</name><usage>read-write</usage><enumeratedValue><name>devided_by_1</name><description>divided by 1</description><value>0</value></enumeratedValue><enumeratedValue><name>devided_by_16</name><description>divided by 16</description><value>1</value></enumeratedValue><enumeratedValue><name>devided_by_256</name><description>divided by 256</description><value>2</value></enumeratedValue></enumeratedValues>
+            </field>
+            <field><name>interrupt_type</name><description>Configure the interrupt type</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth><access>read-write</access><enumeratedValues><name>interrupt_type</name><usage>read-write</usage><enumeratedValue><name>edge</name><description>edge</description><value>0</value></enumeratedValue><enumeratedValue><name>level</name><description>level</description><value>1</value></enumeratedValue></enumeratedValues>
+            </field>
+            </fields>
+                </register>
+                <register>
+                    <name>FRC2_INT</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>FRC2_INT</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc2_int_clr_mask</name>
+                            <description>write to clear the status of the interrupt, if theinterrupt type is "level"
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRC2_ALARM</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>the alarm value for the counter</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>frc2_alarm</name>
+                            <description>the alarm value for the counter</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>UART0</name>
+            <baseAddress>0x60000000</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x000001e0</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>UART_FIFO</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>UART FIFO,length 128</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_rd_byte</name>
+                            <description>R/W share the same address</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    <field><name>rxfifo_write_byte</name><description>R/W share the same address</description><bitOffset>0</bitOffset><bitWidth>8</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>UART_INT_RAW</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>UART INTERRUPT RAW STATE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_raw</name>
+                            <description>The interrupt raw bit for Rx time-out interrupt(depands on
+                                theUART_RX_TOUT_THRHD)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_raw</name>
+                            <description>The interrupt raw bit for Rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_raw</name>
+                            <description>The interrupt raw bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_raw</name>
+                            <description>The interrupt raw bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_raw</name>
+                            <description>The interrupt raw bit for rx fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_raw</name>
+                            <description>The interrupt raw bit for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_raw</name>
+                            <description>The interrupt raw bit for parity check error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_raw</name>
+                            <description>The interrupt raw bit for tx fifo empty interrupt(depands
+                                onUART_TXFIFO_EMPTY_THRHD bits)
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_raw</name>
+                            <description>The interrupt raw bit for rx fifo full interrupt(depands
+                                onUART_RXFIFO_FULL_THRHD bits)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_ST</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>UART INTERRUPT STATEREGISTERUART_INT_RAW&amp;UART_INT_ENA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_st</name>
+                            <description>The interrupt state bit for Rx time-out event</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_st</name>
+                            <description>The interrupt state bit for rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_st</name>
+                            <description>The interrupt state bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_st</name>
+                            <description>The interrupt state bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_st</name>
+                            <description>The interrupt state bit for RX fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_st</name>
+                            <description>The interrupt state for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_st</name>
+                            <description>The interrupt state bit for rx parity error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_st</name>
+                            <description>The interrupt state bit for TX fifo empty</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_st</name>
+                            <description>The interrupt state bit for RX fifo full event</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_ENA</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>UART INTERRUPT ENABLE REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_ena</name>
+                            <description>The interrupt enable bit for rx time-out interrupt</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_ena</name>
+                            <description>The interrupt enable bit for rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_ena</name>
+                            <description>The interrupt enable bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_ena</name>
+                            <description>The interrupt enable bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_ena</name>
+                            <description>The interrupt enable bit for rx fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_ena</name>
+                            <description>The interrupt enable bit for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_ena</name>
+                            <description>The interrupt enable bit for parity error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_ena</name>
+                            <description>The interrupt enable bit for tx fifo empty event</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_ena</name>
+                            <description>The interrupt enable bit for rx fifo full event</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_CLR</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>UART INTERRUPT CLEAR REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_clr</name>
+                            <description>Set this bit to clear the rx time-out interrupt</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_clr</name>
+                            <description>Set this bit to clear the rx byte start interrupt</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_clr</name>
+                            <description>Set this bit to clear the CTS changing interrupt</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_clr</name>
+                            <description>Set this bit to clear the DSR changing interrupt</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_clr</name>
+                            <description>Set this bit to clear the rx fifo over-flow interrupt</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_clr</name>
+                            <description>Set this bit to clear other rx error interrupt</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_clr</name>
+                            <description>Set this bit to clear the parity error interrupt</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_clr</name>
+                            <description>Set this bit to clear the tx fifo empty interrupt</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_clr</name>
+                            <description>Set this bit to clear the rx fifo full interrupt</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CLKDIV</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>UART CLK DIV REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_clkdiv</name>
+                            <description>BAUDRATE = UART_CLK_FREQ / UART_CLKDIV</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_AUTOBAUD</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>UART BAUDRATE DETECT REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>glitch_filt</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>autobaud_en</name>
+                            <description>Set this bit to enable baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_STATUS</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>UART STATUS REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>txd</name>
+                            <description>The level of the uart txd pin</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rtsn</name>
+                            <description>The level of uart rts pin</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dtrn</name>
+                            <description>The level of uart dtr pin</description>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_cnt</name>
+                            <description>Number of data in UART TX fifo</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxd</name>
+                            <description>The level of uart rxd pin</description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ctsn</name>
+                            <description>The level of uart cts pin</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsrn</name>
+                            <description>The level of uart dsr pin</description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_cnt</name>
+                            <description>Number of data in uart rx fifo</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CONF0</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>UART CONFIG0(UART0 and UART1)</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_dtr_inv</name>
+                            <description>Set this bit to inverse uart dtr level</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_rts_inv</name>
+                            <description>Set this bit to inverse uart rts level</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_txd_inv</name>
+                            <description>Set this bit to inverse uart txd level</description>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_dsr_inv</name>
+                            <description>Set this bit to inverse uart dsr level</description>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_cts_inv</name>
+                            <description>Set this bit to inverse uart cts level</description>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_rxd_inv</name>
+                            <description>Set this bit to inverse uart rxd level</description>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_rst</name>
+                            <description>Set this bit to reset uart tx fifo</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_rst</name>
+                            <description>Set this bit to reset uart rx fifo</description>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>tx_flow_en</name>
+                            <description>Set this bit to enable uart tx hardware flow control</description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_loopback</name>
+                            <description>Set this bit to enable uart loopback test mode</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txd_brk</name>
+                            <description>RESERVED, DO NOT CHANGE THIS BIT</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>sw_dtr</name>
+                            <description>sw dtr</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>sw_rts</name>
+                            <description>sw rts</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>stop_bit_num</name>
+                            <description>Set stop bit: 1:1bit 2:1.5bits 3:2bits</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>bit_num</name>
+                            <description>Set bit num: 0:5bits 1:6bits 2:7bits 3:8bits</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity_en</name>
+                            <description>Set this bit to enable uart parity check</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity</name>
+                            <description>Set parity check: 0:even 1:odd, UART CONFIG1</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CONF1</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>Set this bit to enable rx time-out function</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rx_tout_en</name>
+                            <description>Set this bit to enable rx time-out function</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_tout_thrhd</name>
+                            <description>Config bits for rx time-out threshold,uint: byte,0-127</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_flow_en</name>
+                            <description>Set this bit to enable rx hardware flow control</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_flow_thrhd</name>
+                            <description>The config bits for rx flow control threshold,0-127</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_thrhd</name>
+                            <description>The config bits for tx fifo empty threshold,0-127</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_thrhd</name>
+                            <description>The config bits for rx fifo full threshold,0-127</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_LOWPULSE</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>UART_LOWPULSE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>lowpulse_min_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_HIGHPULSE</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>UART_HIGHPULSE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>highpulse_min_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_RXD_CNT</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>UART_RXD_CNT</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxd_edge_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>10</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_DATE</name>
+                    <addressOffset>0x78</addressOffset>
+                    <description>UART HW INFO</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_date</name>
+                            <description>UART HW INFO</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_ID</name>
+                    <addressOffset>0x7c</addressOffset>
+                    <description>UART_ID</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_id</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>UART1</name>
+            <baseAddress>0x60000f00</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x000001e0</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>UART_FIFO</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>UART FIFO,length 128</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_rd_byte</name>
+                            <description>R/W share the same address</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    <field><name>rxfifo_write_byte</name><description>R/W share the same address</description><bitOffset>0</bitOffset><bitWidth>8</bitWidth></field>
+            </fields>
+                </register>
+                <register>
+                    <name>UART_INT_RAW</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>UART INTERRUPT RAW STATE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_raw</name>
+                            <description>The interrupt raw bit for Rx time-out interrupt(depands on
+                                theUART_RX_TOUT_THRHD)
+                            </description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_raw</name>
+                            <description>The interrupt raw bit for Rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_raw</name>
+                            <description>The interrupt raw bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_raw</name>
+                            <description>The interrupt raw bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_raw</name>
+                            <description>The interrupt raw bit for rx fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_raw</name>
+                            <description>The interrupt raw bit for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_raw</name>
+                            <description>The interrupt raw bit for parity check error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_raw</name>
+                            <description>The interrupt raw bit for tx fifo empty interrupt(depands
+                                onUART_TXFIFO_EMPTY_THRHD bits)
+                            </description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_raw</name>
+                            <description>The interrupt raw bit for rx fifo full interrupt(depands
+                                onUART_RXFIFO_FULL_THRHD bits)
+                            </description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_ST</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>UART INTERRUPT STATEREGISTERUART_INT_RAW&amp;UART_INT_ENA</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_st</name>
+                            <description>The interrupt state bit for Rx time-out event</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_st</name>
+                            <description>The interrupt state bit for rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_st</name>
+                            <description>The interrupt state bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_st</name>
+                            <description>The interrupt state bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_st</name>
+                            <description>The interrupt state bit for RX fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_st</name>
+                            <description>The interrupt state for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_st</name>
+                            <description>The interrupt state bit for rx parity error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_st</name>
+                            <description>The interrupt state bit for TX fifo empty</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_st</name>
+                            <description>The interrupt state bit for RX fifo full event</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_ENA</name>
+                    <addressOffset>0xc</addressOffset>
+                    <description>UART INTERRUPT ENABLE REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_ena</name>
+                            <description>The interrupt enable bit for rx time-out interrupt</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_ena</name>
+                            <description>The interrupt enable bit for rx byte start error</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_ena</name>
+                            <description>The interrupt enable bit for CTS changing level</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_ena</name>
+                            <description>The interrupt enable bit for DSR changing level</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_ena</name>
+                            <description>The interrupt enable bit for rx fifo overflow</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_ena</name>
+                            <description>The interrupt enable bit for other rx error</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_ena</name>
+                            <description>The interrupt enable bit for parity error</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_ena</name>
+                            <description>The interrupt enable bit for tx fifo empty event</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_ena</name>
+                            <description>The interrupt enable bit for rx fifo full event</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_INT_CLR</name>
+                    <addressOffset>0x10</addressOffset>
+                    <description>UART INTERRUPT CLEAR REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxfifo_tout_int_clr</name>
+                            <description>Set this bit to clear the rx time-out interrupt</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>brk_det_int_clr</name>
+                            <description>Set this bit to clear the rx byte start interrupt</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>cts_chg_int_clr</name>
+                            <description>Set this bit to clear the CTS changing interrupt</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>dsr_chg_int_clr</name>
+                            <description>Set this bit to clear the DSR changing interrupt</description>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_ovf_int_clr</name>
+                            <description>Set this bit to clear the rx fifo over-flow interrupt</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>frm_err_int_clr</name>
+                            <description>Set this bit to clear other rx error interrupt</description>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>parity_err_int_clr</name>
+                            <description>Set this bit to clear the parity error interrupt</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_int_clr</name>
+                            <description>Set this bit to clear the tx fifo empty interrupt</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_int_clr</name>
+                            <description>Set this bit to clear the rx fifo full interrupt</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CLKDIV</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>UART CLK DIV REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_clkdiv</name>
+                            <description>BAUDRATE = UART_CLK_FREQ / UART_CLKDIV</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_AUTOBAUD</name>
+                    <addressOffset>0x18</addressOffset>
+                    <description>UART BAUDRATE DETECT REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>glitch_filt</name>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>autobaud_en</name>
+                            <description>Set this bit to enable baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_STATUS</name>
+                    <addressOffset>0x1c</addressOffset>
+                    <description>UART STATUS REGISTER</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>txd</name>
+                            <description>The level of the uart txd pin</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rtsn</name>
+                            <description>The level of uart rts pin</description>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dtrn</name>
+                            <description>The level of uart dtr pin</description>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>txfifo_cnt</name>
+                            <description>Number of data in UART TX fifo</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxd</name>
+                            <description>The level of uart rxd pin</description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ctsn</name>
+                            <description>The level of uart cts pin</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>dsrn</name>
+                            <description>The level of uart dsr pin</description>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_cnt</name>
+                            <description>Number of data in uart rx fifo</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CONF0</name>
+                    <addressOffset>0x20</addressOffset>
+                    <description>UART CONFIG0(UART0 and UART1)</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_dtr_inv</name>
+                            <description>Set this bit to inverse uart dtr level</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_rts_inv</name>
+                            <description>Set this bit to inverse uart rts level</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_txd_inv</name>
+                            <description>Set this bit to inverse uart txd level</description>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_dsr_inv</name>
+                            <description>Set this bit to inverse uart dsr level</description>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_cts_inv</name>
+                            <description>Set this bit to inverse uart cts level</description>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_rxd_inv</name>
+                            <description>Set this bit to inverse uart rxd level</description>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_rst</name>
+                            <description>Set this bit to reset uart tx fifo</description>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_rst</name>
+                            <description>Set this bit to reset uart rx fifo</description>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>tx_flow_en</name>
+                            <description>Set this bit to enable uart tx hardware flow control</description>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>uart_loopback</name>
+                            <description>Set this bit to enable uart loopback test mode</description>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txd_brk</name>
+                            <description>RESERVED, DO NOT CHANGE THIS BIT</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>sw_dtr</name>
+                            <description>sw dtr</description>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>sw_rts</name>
+                            <description>sw rts</description>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>stop_bit_num</name>
+                            <description>Set stop bit: 1:1bit 2:1.5bits 3:2bits</description>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>bit_num</name>
+                            <description>Set bit num: 0:5bits 1:6bits 2:7bits 3:8bits</description>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity_en</name>
+                            <description>Set this bit to enable uart parity check</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>parity</name>
+                            <description>Set parity check: 0:even 1:odd, UART CONFIG1</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_CONF1</name>
+                    <addressOffset>0x24</addressOffset>
+                    <description>Set this bit to enable rx time-out function</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rx_tout_en</name>
+                            <description>Set this bit to enable rx time-out function</description>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_tout_thrhd</name>
+                            <description>Config bits for rx time-out threshold,uint: byte,0-127</description>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_flow_en</name>
+                            <description>Set this bit to enable rx hardware flow control</description>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rx_flow_thrhd</name>
+                            <description>The config bits for rx flow control threshold,0-127</description>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>txfifo_empty_thrhd</name>
+                            <description>The config bits for tx fifo empty threshold,0-127</description>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>rxfifo_full_thrhd</name>
+                            <description>The config bits for rx fifo full threshold,0-127</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_LOWPULSE</name>
+                    <addressOffset>0x28</addressOffset>
+                    <description>UART_LOWPULSE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>lowpulse_min_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_HIGHPULSE</name>
+                    <addressOffset>0x2c</addressOffset>
+                    <description>UART_HIGHPULSE</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>highpulse_min_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>20</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_RXD_CNT</name>
+                    <addressOffset>0x30</addressOffset>
+                    <description>UART_RXD_CNT</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>rxd_edge_cnt</name>
+                            <description>used in baudrate detect</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>10</bitWidth>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_DATE</name>
+                    <addressOffset>0x78</addressOffset>
+                    <description>UART HW INFO</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_date</name>
+                            <description>UART HW INFO</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UART_ID</name>
+                    <addressOffset>0x7c</addressOffset>
+                    <description>UART_ID</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>uart_id</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>WDT</name>
+            <baseAddress>0x60000900</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0x00000080</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>WDT_CTL</name>
+                    <addressOffset>0x0</addressOffset>
+                    <description>WDT_CTL</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>WDT_OP</name>
+                    <addressOffset>0x4</addressOffset>
+                    <description>WDT_OP</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>WDT_OP_ND</name>
+                    <addressOffset>0x8</addressOffset>
+                    <description>WDT_OP_ND</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>WDT_RST</name>
+                    <addressOffset>0x14</addressOffset>
+                    <description>WDT_RST</description>
+                    <size>32</size>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <name>Register</name>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+    <peripheral><name>RNG</name><description>RNG register</description><baseAddress>0x3FF20E44</baseAddress><addressBlock><offset>0</offset><size>32</size><usage>RNG register</usage></addressBlock><registers><register><name>rng</name><fields /><description>RNG register</description><addressOffset>0</addressOffset><size>32</size><access>read-only</access><resetValue>0</resetValue></register>
+        </registers></peripheral>
+    <peripheral><name>WATCHDOG</name><description>Watchdog registers</description><baseAddress>0x60000900</baseAddress><addressBlock><offset>0</offset><size>24</size><usage>Watchdog registers</usage></addressBlock><registers><register><name>ctl</name><fields><field><name>enable</name><description>Enable the watchdog timer.</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>stage_1_no_reset</name><description>When set to 1, and running in two-stage mode, it turns the watchdog into a single shot timer that doesn't reset the device.</description><bitOffset>1</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>stage_1_disable</name><description>Set to 1 to disable the stage 1 of the watchdog timer</description><bitOffset>2</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>unknown_3</name><bitOffset>3</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>unknown_4</name><bitOffset>4</bitOffset><bitWidth>1</bitWidth></field>
+            <field><name>unknown_5</name><bitOffset>5</bitOffset><bitWidth>1</bitWidth></field>
+            </fields><description>Watchdog control</description><addressOffset>0</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>reload_stage0</name><fields /><description>Reload value for stage 0</description><addressOffset>4</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>reload_stage1</name><fields /><description>Reload value for stage 1</description><addressOffset>8</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>count</name><fields /><description>Watchdog clock cycle count</description><addressOffset>12</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>stage</name><fields /><description>The current watchdog stage</description><addressOffset>16</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>reset</name><fields /><description>Watchdog reset</description><addressOffset>20</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        <register><name>reset_stage</name><fields /><description>Watchdog stage reset</description><addressOffset>24</addressOffset><size>32</size><access>read-write</access><resetValue>0</resetValue></register>
+        </registers></peripheral>
+    </peripherals>
+</device>


### PR DESCRIPTION
This PR is very similar to #110. This SVD file has been generated mostly from C header files instead of the ESP-IDF, with lots of manual tuning.

@icewind1991 are you okay with including this file here? It may need updates sometimes, but having it here makes it much easier to support the ESP8266 in TinyGo (see https://github.com/tinygo-org/tinygo/pull/900).