### PR TITLE
Fix polarity of remove_reserved

### DIFF
--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -245,7 +245,7 @@ class SVDParser(object):
         fields = []
         for field_node in register_node.findall('.//field'):
             node = self._parse_field(field_node)
-            if self.remove_reserved or 'reserved' not in node.name.lower():
+            if not self.remove_reserved or 'reserved' not in node.name.lower():
                 fields.append(node)
 
         dim = _get_int(register_node, 'dim')


### PR DESCRIPTION
The remove_reserved argument to SVDParser.for_packages_svd() did the
opposite of what the name suggested it would do. This fixes that.

Fixes #113.
