### PR TITLE
Fix derived register attributes and add test case

### DIFF
--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -231,7 +231,7 @@ class SVDParser(object):
 
         return SVDField(
             name=_get_text(field_node, 'name'),
-            derived_from=_get_text(field_node, 'derivedFrom'),
+            derived_from=field_node.get('derivedFrom'),
             description=_get_text(field_node, 'description'),
             bit_offset=bit_offset,
             bit_width=bit_width,
@@ -250,7 +250,7 @@ class SVDParser(object):
 
         dim = _get_int(register_node, 'dim')
         name = _get_text(register_node, 'name')
-        derived_from = _get_text(register_node, 'derivedFrom')
+        derived_from = register_node.get('derivedFrom')
         description = _get_text(register_node, 'description')
         address_offset = _get_int(register_node, 'addressOffset')
         size = _get_int(register_node, 'size')
@@ -318,7 +318,7 @@ class SVDParser(object):
     def _parse_cluster(self, cluster_node):
         dim = _get_int(cluster_node, 'dim')
         name = _get_text(cluster_node, 'name')
-        derived_from = _get_text(cluster_node, 'derivedFrom')
+        derived_from = cluster_node.get('derivedFrom')
         description = _get_text(cluster_node, 'description')
         address_offset = _get_int(cluster_node, 'addressOffset')
         size = _get_int(cluster_node, 'size')

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -203,7 +203,7 @@ class TestParserNordic(unittest.TestCase):
         self.assertEqual(list(sorted([p.name for p in device.peripherals])),
                          ['AAR', 'ADC', 'CCM', 'CLOCK', 'ECB', 'FICR', 'GPIO', 'GPIOTE', 'LPCOMP', 'MPU',
                           'NVMC', 'POWER', 'PPI', 'QDEC', 'RADIO', 'RNG', 'RTC0', 'RTC1', 'SPI0', 'SPI1',
-                          'SPIS1','SWI', 'TEMP', 'TIMER0', 'TIMER1', 'TIMER2', 'TWI0', 'TWI1', 'UART0', 'UICR', 
+                          'SPIS1','SWI', 'TEMP', 'TIMER0', 'TIMER1', 'TIMER2', 'TWI0', 'TWI1', 'UART0', 'UICR',
                           'WDT'
                           ])
 
@@ -269,6 +269,20 @@ class TestParserNordic(unittest.TestCase):
         reg = [r for r in regs if r.name == "CH[15]_TEP"][0]
         self.assertEqual(reg.address_offset, 0x58C)
 
+class TestParserSpansion(unittest.TestCase):
+    def test_derived_register_attributes(self):
+        parser = SVDParser.for_packaged_svd('Spansion', 'MB9BF46xx.svd')
+        mft0_regs = [p.registers for p in parser.get_device().peripherals if p.name == "MFT0"][0]
+        reg_map = {r.name: r for r in mft0_regs}
+
+        # Test to see if the derived register has the attributes of the base register
+        base_reg = reg_map['FRT_TCCP0']
+        derived_reg = reg_map['FRT_TCCP1']
+
+        self.assertEqual(derived_reg.size, base_reg.size)
+        self.assertEqual(derived_reg.access, base_reg.access)
+        self.assertEqual(derived_reg.reset_value, base_reg.reset_value)
+        self.assertEqual(derived_reg.reset_mask, base_reg.reset_mask)
 
 class TestParserExample(unittest.TestCase):
     def test_derived_from_registers(self):


### PR DESCRIPTION
In particular, I was running into issues with the `FRT_TCCP1` register, derived from `FRT_TCCP0` in the `Spansion/MB9BF46xx.svd`.