### PR TITLE
Support for Multiple Peripheral's Address Blocks

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -459,7 +459,7 @@ class SVDInterrupt(SVDElement):
 
 class SVDPeripheral(SVDElement):
     def __init__(self, name, version, derived_from, description,
-                 prepend_to_name, base_address, address_block,
+                 prepend_to_name, base_address, address_blocks,
                  interrupts, registers, register_arrays, size, access,
                  protection, reset_value, reset_mask,
                  group_name, append_to_name, disable_condition,
@@ -473,7 +473,7 @@ class SVDPeripheral(SVDElement):
         self._description = description
         self._prepend_to_name = prepend_to_name
         self._base_address = base_address
-        self._address_block = address_block
+        self._address_blocks = address_blocks
         self._interrupts = interrupts
         self._registers = registers
         self._register_arrays = register_arrays

--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -443,12 +443,11 @@ class SVDParser(object):
                 interrupts.append(interrupt)
         interrupts = interrupts if interrupts else None
 
-        # parse address block if any
-        address_block_nodes = peripheral_node.findall('./addressBlock')
-        if address_block_nodes:
-            address_block = self._parse_address_block(address_block_nodes[0])
-        else:
-            address_block = None
+        # parse all address blocks for the peripheral
+        address_blocks = []
+        for address_block_node in peripheral_node.findall('./addressBlock'):
+            address_blocks.append(self._parse_address_block(address_block_node))
+        address_blocks = address_blocks if address_blocks else None
 
         return SVDPeripheral(
             # <name>identifierType</name>
@@ -486,7 +485,7 @@ class SVDParser(object):
             #     <usage>usageType</usage>
             #     <protection>protectionStringType</protection>
             # </addressBlock>
-            address_block=address_block,
+            address_blocks=address_blocks,
 
             # <interrupt>
             #     <name>identifierType</name>
@@ -558,6 +557,3 @@ class SVDParser(object):
 
 def duplicate_array_of_registers(svdreg):  # expects a SVDRegister which is an array of registers
     assert (svdreg.dim == len(svdreg.dim_index))
-
-
-

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -109,7 +109,7 @@ class TestParserFreescale(unittest.TestCase):
         self.assertEqual(uart0.base_address, 0x4006A000)
 
         # address block verification
-        block = uart0.address_block
+        block = uart0.address_blocks[0]
         self.assertEqual(block.usage, 'registers')
         self.assertEqual(block.size, 0x0C)
         self.assertEqual(block.offset, 0)
@@ -215,7 +215,7 @@ class TestParserNordic(unittest.TestCase):
         self.assertEqual(spi1.base_address, 0x40004000)
 
         # address block verification
-        block = spi1.address_block
+        block = spi1.address_blocks[0]
         self.assertEqual(block.usage, 'registers')
         self.assertEqual(block.size, 0x1000)
         self.assertEqual(block.offset, 0)


### PR DESCRIPTION

According to the official CMSIS-SVD XML file format description this is possible to have multiple `AddressBlock` in the peripheral description. This seem logical since a peripheral can have multiple reserved blocks localized at different offsets in the peripheral address range.

```text
/device/peripherals/peripheral/addressBlock element
Specify an address range uniquely mapped to this peripheral. A peripheral must have at least one address block.*
```
(https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_peripherals.html#elem_addressBlock)

For example, the Thoshiba/M367.svd description file contains several PL011 peripherals which contains multiple `AddressBlock`.

Thoshiba/M367.svd (https://github.com/posborne/cmsis-svd/blob/master/data/Toshiba/M367.svd#L2859) extract for UART4:
```xml
<peripheral>
  <name>UART4</name>
  <description>ARM Prime Cell PL011</description>
  <baseAddress>0x40048000</baseAddress>
  <addressBlock>
    <offset>0x0</offset>
    <size>0x8</size>
    <usage>registers</usage>
  </addressBlock>
  <addressBlock>
    <offset>0x8</offset>
    <size>0x10</size>
    <usage>reserved</usage>
  </addressBlock>
  <addressBlock>
    <offset>0x18</offset>
    <size>0x4</size>
    <usage>registers</usage>
  </addressBlock>
  <addressBlock>
    <offset>0x1c</offset>
    <size>0x4</size>
    <usage>reserved</usage>
  </addressBlock>
  <addressBlock>
    <offset>0x20</offset>
    <size>0x2c</size>
    <usage>registers</usage>
  </addressBlock>
```

Here an extract of the Summary of registers of the PL011 documention (ARM DDI 0183G https://documentation-service.arm.com/static/5e8e36c2fd977155116a90b5) corresponding to the registers of the UARTx peripherals of the Thoshiba/M367.svd.

```text
Offset      Name      Type    Reset         Width     Description
-----------------------------------------------------------------------------------------------------
0x000       UARTDR    RW      0x---         12/8      Data Register, UARTDR on page 3-5
-----------------------------------------------------------------------------------------------------
0x004       UARTRSR   RW      0x0           4/0       Receive Status Register/Error Clear Register,
            /UARTECR                                  UARTRSR/UARTECR on page 3-6
-----------------------------------------------------------------------------------------------------
0x008-0x014 -         -       -             -         Reserved
-----------------------------------------------------------------------------------------------------
0x018       UARTFR    RO      0b-10010---   9         Flag Register, UARTFR on page 3-8
-----------------------------------------------------------------------------------------------------
0x01C       -         -       -             -         Reserved
-----------------------------------------------------------------------------------------------------
0x020       UARTILPR  RW      0x00          8         IrDA Low-Power Counter Register, UARTILPR on
                                                      page 3-9
[...]
```

The patch fix the parser and the model to have a new field `address_blocks` in the `SVDPeripheral` structure. The patch remove the `address_block` field. Exemple with the UART4 (PL011) peripheral of the Thoshiba/M367.svd.

```text
>> from cmsis_svd.parser import SVDParser
>> parser = SVDParser.for_packaged_svd('Toshiba', 'M367.svd')
>>> parser.get_device().peripherals[5].name
'UART4'
>>> parser.get_device().peripherals[5].description
'ARM Prime Cell PL011'
>>> for address_block in parser.get_device().peripherals[5].address_blocks:
...     print('offset: {:#0x}, size: {:#0x}, usage: {}'.format(address_block.offset, address_block.size, address_block.usage))
offset: 0x0, size: 0x8, usage: registers
offset: 0x8, size: 0x10, usage: reserved
offset: 0x18, size: 0x4, usage: registers
offset: 0x1c, size: 0x4, usage: reserved
offset: 0x20, size: 0x2c, usage: registers
```

The tests and test fixture (MKL25Z4.json) are fixed and all the tests passe with success.

