### PR TITLE
Fix missing parent association for SVDPeripheral register arrays

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -492,6 +492,8 @@ class SVDPeripheral(SVDElement):
             i.parent = self
         for r in _none_as_empty(self._registers):
             r.parent = self
+        for arr in _none_as_empty(self._register_arrays):
+            arr.parent = self
 
     def __getattr__(self, attr):
         return self._lookup_possibly_derived_attribute(attr)


### PR DESCRIPTION

Parent association for SVDPeripheral register arrays is missing.

```text
>>> from cmsis_svd.parser import SVDParser
>>> dev =  SVDParser.for_packaged_svd('Atmel', 'AT91SAM9G35.svd').get_device()
>>> spi0 = list(filter(lambda p: p.name == 'SPI0',  dev.peripherals))[0]
>>> csr_1 = list(filter(lambda r: r.name == 'CSR[1]',  spi0.registers))[0]
>>> type(csr_1.parent)
<class 'NoneType'>
```

After fix.

```text
>>> from cmsis_svd.parser import SVDParser
>>> dev =  SVDParser.for_packaged_svd('Atmel', 'AT91SAM9G35.svd').get_device()
>>> spi0 = list(filter(lambda p: p.name == 'SPI0',  dev.peripherals))[0]
>>> csr_1 = list(filter(lambda r: r.name == 'CSR[1]',  spi0.registers))[0]
>>> type(csr_1.parent)
<class 'cmsis_svd.model.SVDPeripheral'>
>>> csr_1.parent.name
'SPI0'
```
