### PR TITLE
Fix typo in alternatePeripheral XML tag name

### DIFF
--- a/python/cmsis_svd/parser.py
+++ b/python/cmsis_svd/parser.py
@@ -725,7 +725,7 @@ class SVDParser:
             name=_get_text(peripheral_node, 'name'),
             version=_get_text(peripheral_node, 'version'),
             description=_get_text(peripheral_node, 'description'),
-            alternate_peripheral=_get_text(peripheral_node, 'alternaPeripheral'),
+            alternate_peripheral=_get_text(peripheral_node, 'alternatePeripheral'),
             group_name=_get_text(peripheral_node, 'groupName'),
             prepend_to_name=_get_text(peripheral_node, 'prependToName'),
             append_to_name=_get_text(peripheral_node, 'appendToName'),


### PR DESCRIPTION
## Summary
- Fix typo: `'alternaPeripheral'` → `'alternatePeripheral'` in parser.py line 728

## Problem
The SVD parser was looking for the XML tag `alternaPeripheral` (missing "te") instead of the correct `alternatePeripheral`. This caused the `alternate_peripheral` attribute to always be `None` for peripherals that specify this field.

## Impact
The `alternatePeripheral` element is part of the CMSIS-SVD specification and is used to indicate that multiple peripheral definitions share the same address space but provide different logical views of the same physical register block. For example, the NXP MIMXRT1021 SVD file uses this to indicate that `PMU`, `TEMPMON`, `USB_ANALOG`, and `XTALOSC24M` are alternate views of `CCM_ANALOG`.

Without this fix, code generators cannot detect these relationships and may incorrectly create overlapping memory regions.

## Testing
Verified with NXP MIMXRT1021.xml SVD file:
- Before fix: `peripheral.alternate_peripheral` returns `None` for all peripherals
- After fix: `peripheral.alternate_peripheral` correctly returns `'CCM_ANALOG'` for PMU, TEMPMON, USB_ANALOG, and XTALOSC24M peripherals

🤖 Generated with [Claude Code](https://claude.ai/code)